### PR TITLE
사용자 엔티티 그룹 관련 필드 추가

### DIFF
--- a/server/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/server/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -25,4 +25,7 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
     private final Long kakaoId;
+    private String nickname;
+    private String profileLocation;
+    private Integer orderInGroup;
 }

--- a/server/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/server/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -1,11 +1,15 @@
 package com.exchangediary.member.domain.entity;
 
 import com.exchangediary.global.domain.entity.BaseEntity;
+import com.exchangediary.group.domain.entity.Group;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,4 +32,7 @@ public class Member extends BaseEntity {
     private String nickname;
     private String profileLocation;
     private Integer orderInGroup;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
 }


### PR DESCRIPTION
## Work Description
> 한 줄 요약: 사용자 엔티티 그룹 관련 필드 추가

- 그룹 관련 필드를 사용자 엔티티에 추가
  - 닉네임, 일기 작성 순서, 프로필 이미지 경로

## ISSUE
- closed #124 

## Screenshot
<img width="535" alt="Screenshot 2024-10-01 at 12 28 18 AM" src="https://github.com/user-attachments/assets/0114c6d6-5c90-420a-9aa7-7737bd54e80a">
