### PR TITLE
일기 조회 API 수정

### DIFF
--- a/server/src/main/java/com/exchangediary/diary/ui/dto/response/DiaryDetailResponse.java
+++ b/server/src/main/java/com/exchangediary/diary/ui/dto/response/DiaryDetailResponse.java
@@ -2,8 +2,9 @@ package com.exchangediary.diary.ui.dto.response;
 
 import com.exchangediary.diary.domain.entity.Diary;
 import com.exchangediary.diary.domain.entity.UploadImage;
-import com.exchangediary.global.util.DateTimeUtil;
 import lombok.Builder;
+
+import java.time.format.DateTimeFormatter;
 
 @Builder
 public record DiaryDetailResponse(
@@ -16,7 +17,7 @@ public record DiaryDetailResponse(
     public static DiaryDetailResponse of (Diary diary) {
        return DiaryDetailResponse.builder()
                 .diaryId(diary.getId())
-                .createdAt(DateTimeUtil.KOREAN_DATE_FORMAT.format(diary.getCreatedAt()))
+                .createdAt(diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.M.dd")))
                 .content(diary.getContent())
                 .moodLocation(diary.getMoodLocation())
                 .imageApiPath(getImageApiPath(diary.getUploadImage()))

--- a/server/src/main/java/com/exchangediary/global/util/DateTimeUtil.java
+++ b/server/src/main/java/com/exchangediary/global/util/DateTimeUtil.java
@@ -1,7 +1,0 @@
-package com.exchangediary.global.util;
-
-import java.time.format.DateTimeFormatter;
-
-public class DateTimeUtil {
-    public static final DateTimeFormatter KOREAN_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
-}


### PR DESCRIPTION
## Work Description
> 한 줄 요약: 일기 조회 API 날짜 형식 수정

- 디자인에 맞게 일기 조회 API 날짜 형식을 수정했습니다. 
  - yyyy년 M월 dd일 ➡️ yyyy.M.dd

## ISSUE
- closed #137 


## Screenshot
<img width="817" alt="Screenshot 2024-10-01 at 5 24 46 PM" src="https://github.com/user-attachments/assets/58b35195-a94d-45e1-9c56-84decf3a361a">
