### PR TITLE
그룹 코드 유효성 검증 API 개발

### DIFF
--- a/server/src/main/java/com/exchangediary/global/exception/ErrorCode.java
+++ b/server/src/main/java/com/exchangediary/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // Not Found
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "일기를 찾을 수 없습니다."),
     UPLOAD_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "일기 업로드 이미지를 찾을 수 없습니다."),
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹을 찾을 수 없습니다."),
 
     // Kakao Login
     FAILED_TO_ISSUE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "kakao 토큰 발급에 실패했습니다."),

--- a/server/src/main/java/com/exchangediary/global/exception/serviceexception/notfound/GroupNotFoundException.java
+++ b/server/src/main/java/com/exchangediary/global/exception/serviceexception/notfound/GroupNotFoundException.java
@@ -1,0 +1,9 @@
+package com.exchangediary.global.exception.serviceexception.notfound;
+
+import com.exchangediary.global.exception.ErrorCode;
+
+public class GroupNotFoundException extends NotFoundException {
+    public GroupNotFoundException(String value) {
+        super(value, ErrorCode.GROUP_NOT_FOUND);
+    }
+}

--- a/server/src/main/java/com/exchangediary/group/domain/GroupRepository.java
+++ b/server/src/main/java/com/exchangediary/group/domain/GroupRepository.java
@@ -3,5 +3,8 @@ package com.exchangediary.group.domain;
 import com.exchangediary.group.domain.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GroupRepository extends JpaRepository<Group, Long> {
+    Optional<Group> findByCode(String code);
 }

--- a/server/src/main/java/com/exchangediary/group/service/GroupCodeService.java
+++ b/server/src/main/java/com/exchangediary/group/service/GroupCodeService.java
@@ -1,5 +1,9 @@
 package com.exchangediary.group.service;
 
+import com.exchangediary.global.exception.serviceexception.notfound.GroupNotFoundException;
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.domain.entity.Group;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -7,11 +11,21 @@ import java.util.Base64;
 import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class GroupCodeService {
+    private final GroupRepository groupRepository;
+
     public String generateCode(String groupName) {
         LocalDateTime today = LocalDateTime.now();
         String code = groupName + today + UUID.randomUUID();
 
         return Base64.getEncoder().encodeToString(code.getBytes());
+    }
+
+    public Long verifyCode(String code) {
+        Group group = groupRepository.findByCode(code)
+                .orElseThrow(() -> new GroupNotFoundException(code));
+
+        return group.getId();
     }
 }

--- a/server/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
+++ b/server/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
@@ -1,0 +1,31 @@
+package com.exchangediary.group.ui;
+
+import com.exchangediary.group.service.GroupCodeService;
+import com.exchangediary.group.ui.dto.request.GroupCodeRequest;
+import com.exchangediary.group.ui.dto.response.GroupIdResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups")
+public class ApiGroupController {
+    private final GroupCodeService groupCodeService;
+
+    @PostMapping("/code/verify")
+    public ResponseEntity<GroupIdResponse> verifyGroupCode(
+            @RequestBody @Valid GroupCodeRequest request
+    ) {
+        Long groupId = groupCodeService.verifyCode(request.code());
+        GroupIdResponse response = GroupIdResponse.builder()
+                .groupId(groupId)
+                .build();
+        return ResponseEntity
+                .ok(response);
+    }
+}

--- a/server/src/main/java/com/exchangediary/group/ui/dto/request/GroupCodeRequest.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/request/GroupCodeRequest.java
@@ -1,0 +1,8 @@
+package com.exchangediary.group.ui.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record GroupCodeRequest(
+        @NotEmpty String code
+) {
+}

--- a/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupIdResponse.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupIdResponse.java
@@ -1,0 +1,9 @@
+package com.exchangediary.group.ui.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GroupIdResponse(
+    Long groupId
+) {
+}

--- a/server/src/test/java/com/exchangediary/group/GroupCodeServiceTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCodeServiceTest.java
@@ -1,27 +1,58 @@
 package com.exchangediary.group;
 
+import com.exchangediary.global.exception.serviceexception.notfound.GroupNotFoundException;
+import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.service.GroupCodeService;
+import com.exchangediary.group.service.GroupCommandService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class GroupCodeServiceTest {
     private static final String GROUP_NAME = "버니즈";
     @SpyBean
     private GroupCodeService groupCodeService;
+    @Autowired
+    private GroupCommandService groupCommandService;
 
     @Test
     void 그룹_코드_생성() {
-        String groupName = "버디즈";
-        String encodedCode = groupCodeService.generateCode(groupName);
+        String encodedCode = groupCodeService.generateCode(GROUP_NAME);
 
         String code = new String(Base64.getDecoder().decode(encodedCode));
 
-        assertThat(code.substring(0, 3)).isEqualTo(groupName);
+        assertThat(code.substring(0, 3)).isEqualTo(GROUP_NAME);
+    }
+
+    @Test
+    void 그룹_코드_검증_성공() {
+        String code = "valid-code";
+        when(groupCodeService.generateCode(any(String.class))).thenReturn(code);
+        Group group = groupCommandService.createGroup(GROUP_NAME);
+
+        Long groupId = groupCodeService.verifyCode(code);
+
+        assertThat(groupId).isEqualTo(group.getId());
+    }
+
+    @Test
+    void 그룹_코드_검증_실패() {
+        groupCommandService.createGroup(GROUP_NAME);
+        String code = "invalid-code";
+
+        GroupNotFoundException exception = assertThrows(GroupNotFoundException.class, () ->
+            groupCodeService.verifyCode(code)
+        );
+
+        assertThat(exception.getValue()).isEqualTo(code);
     }
 }

--- a/server/src/test/java/com/exchangediary/group/GroupCodeTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCodeTest.java
@@ -1,0 +1,86 @@
+package com.exchangediary.group;
+
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.domain.entity.Group;
+import com.exchangediary.group.service.GroupCommandService;
+import com.exchangediary.group.ui.dto.request.GroupCodeRequest;
+import com.exchangediary.group.ui.dto.response.GroupIdResponse;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GroupCodeTest {
+    private static final String API_PATH = "/api/groups/code/verify";
+    @LocalServerPort
+    private int port;
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private GroupCommandService groupCommandService;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        groupRepository.deleteAllInBatch();
+    }
+
+    /* TODO: 시나리오 따라서 테스트 수정
+     * 1. 그룹 생성
+     * 2. 사용자 정보 수정 -> 그룹 코드 반환
+     * 3. 그룹 코드 유효성 검사
+     */
+    @Test
+    void 그룹_코드_유효성_검증_성공() {
+        String groupName = "버니즈";
+        Group group = groupCommandService.createGroup(groupName);
+        GroupCodeRequest groupCodeRequest = new GroupCodeRequest(group.getCode());
+
+        Long groupId = RestAssured
+                .given().log().all()
+                .body(groupCodeRequest)
+                .contentType(ContentType.JSON)
+                .when().post(API_PATH)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(GroupIdResponse.class)
+                .groupId();
+
+        assertThat(groupId).isEqualTo(group.getId());
+    }
+
+    @Test
+    void 그룹_코드_유효성_검증_실패() {
+        String groupName = "버니즈";
+        Group group = groupCommandService.createGroup(groupName);
+        GroupCodeRequest groupCodeRequest = new GroupCodeRequest(group.getCode() + "invalid");
+
+        RestAssured
+                .given().log().all()
+                .body(groupCodeRequest)
+                .contentType(ContentType.JSON)
+                .when().post(API_PATH)
+                .then().log().all()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    void 그룹_코드_유효성_검증_실패_빈코드() {
+        GroupCodeRequest groupCodeRequest = new GroupCodeRequest("");
+
+        RestAssured
+                .given().log().all()
+                .body(groupCodeRequest)
+                .contentType(ContentType.JSON)
+                .when().post(API_PATH)
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+}


### PR DESCRIPTION
## Work Description
> 한 줄 요약: 그룹 코드 유효성 검증 서비스 개발

> #107 이슈에 연결된 브렌치가 닫혀서 자동으로 #127 pr이 닫혀버려서 다시 pr 올립니다.

- 그룹 코드 유효성 검증을 구현했습니다.
- 그룹 코드 유효성 검증 실패 시, `GroupNotFoundException`을 던지도록 구현했습니다.
- 그룹 코드 유효성 검증 성공과 실패 경우에 대한 테스트를 작성하였습니다.
- 그룹 코드 유효성 검증과 관련된 API가 확정되어서 컨트롤러를 추가했습니다.
- 그에 따른 웹 서버 + 클라이언트 RestAssured를 사용한 통합 테스트도 작성했습니다.
  - 추후 그룹 생성 API, 사용자 정보 수정 API가 구현 완료되면 주석으로 작성된 시나리오대로 테스트 수정해볼 예정입니다.

## ISSUE
- closed #108
- closed #127 

## Screenshot
<img width="329" alt="Screenshot 2024-10-01 at 3 12 15 AM" src="https://github.com/user-attachments/assets/b7e44805-9b25-4b58-aad1-911fd119b58d">
<img width="445" alt="Screenshot 2024-10-02 at 2 56 22 AM" src="https://github.com/user-attachments/assets/1521eb47-1cd4-4ea1-9268-91bbaee057da">


## To Reviewers
많은 피드백 부탁드려용 🤗
