### PR TITLE
그룹 생성 API 개발

### DIFF
--- a/server/src/main/java/com/exchangediary/group/domain/entity/Group.java
+++ b/server/src/main/java/com/exchangediary/group/domain/entity/Group.java
@@ -27,4 +27,13 @@ public class Group {
     private Integer numberOfMembers;
     private Integer currentOrder;
     private String code;
+
+    public static Group of(String groupName, String code) {
+        return Group.builder()
+                .name(groupName)
+                .numberOfMembers(0)
+                .currentOrder(0)
+                .code(code)
+                .build();
+    }
 }

--- a/server/src/main/java/com/exchangediary/group/service/GroupCommandService.java
+++ b/server/src/main/java/com/exchangediary/group/service/GroupCommandService.java
@@ -2,6 +2,7 @@ package com.exchangediary.group.service;
 
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
+import com.exchangediary.group.ui.dto.response.GroupIdResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,13 +14,14 @@ public class GroupCommandService {
     private final GroupRepository groupRepository;
     private final GroupCodeService groupCodeService;
 
-    public Group createGroup(String groupName) {
+    public GroupIdResponse createGroup(String groupName) {
         Group group = Group.builder()
                 .name(groupName)
                 .numberOfMembers(0)
                 .currentOrder(0)
                 .code(groupCodeService.generateCode(groupName))
                 .build();
-        return groupRepository.save(group);
+        groupRepository.save(group);
+        return GroupIdResponse.of(group);
     }
 }

--- a/server/src/main/java/com/exchangediary/group/service/GroupCommandService.java
+++ b/server/src/main/java/com/exchangediary/group/service/GroupCommandService.java
@@ -15,13 +15,8 @@ public class GroupCommandService {
     private final GroupCodeService groupCodeService;
 
     public GroupIdResponse createGroup(String groupName) {
-        Group group = Group.builder()
-                .name(groupName)
-                .numberOfMembers(0)
-                .currentOrder(0)
-                .code(groupCodeService.generateCode(groupName))
-                .build();
+        Group group = Group.of(groupName, groupCodeService.generateCode(groupName));
         groupRepository.save(group);
-        return GroupIdResponse.of(group);
+        return GroupIdResponse.from(group.getId());
     }
 }

--- a/server/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
+++ b/server/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
@@ -1,7 +1,9 @@
 package com.exchangediary.group.ui;
 
 import com.exchangediary.group.service.GroupCodeService;
+import com.exchangediary.group.service.GroupCommandService;
 import com.exchangediary.group.ui.dto.request.GroupCodeRequest;
+import com.exchangediary.group.ui.dto.request.GroupNameRequest;
 import com.exchangediary.group.ui.dto.response.GroupIdResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +13,24 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URI;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups")
 public class ApiGroupController {
+    private final GroupCommandService groupCommandService;
     private final GroupCodeService groupCodeService;
+
+    @PostMapping
+    public ResponseEntity<GroupIdResponse> createGroup(
+            @RequestBody @Valid GroupNameRequest request
+    ) {
+        GroupIdResponse groupIdResponse = groupCommandService.createGroup(request.groupName());
+        return ResponseEntity
+                .created(URI.create("/api/groups/" + groupIdResponse.groupId()))
+                .body(groupIdResponse);
+    }
 
     @PostMapping("/code/verify")
     public ResponseEntity<GroupIdResponse> verifyGroupCode(

--- a/server/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
+++ b/server/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
@@ -37,10 +37,7 @@ public class ApiGroupController {
             @RequestBody @Valid GroupCodeRequest request
     ) {
         Long groupId = groupCodeService.verifyCode(request.code());
-        GroupIdResponse response = GroupIdResponse.builder()
-                .groupId(groupId)
-                .build();
         return ResponseEntity
-                .ok(response);
+                .ok(GroupIdResponse.from(groupId));
     }
 }

--- a/server/src/main/java/com/exchangediary/group/ui/dto/request/GroupNameRequest.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/request/GroupNameRequest.java
@@ -1,0 +1,8 @@
+package com.exchangediary.group.ui.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GroupNameRequest(
+        @NotBlank String groupName
+) {
+}

--- a/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupIdResponse.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupIdResponse.java
@@ -7,9 +7,9 @@ import lombok.Builder;
 public record GroupIdResponse(
     Long groupId
 ) {
-    public static GroupIdResponse of(Group group) {
+    public static GroupIdResponse from(Long groupId) {
         return GroupIdResponse.builder()
-                .groupId(group.getId())
+                .groupId(groupId)
                 .build();
     }
 }

--- a/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupIdResponse.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupIdResponse.java
@@ -1,9 +1,15 @@
 package com.exchangediary.group.ui.dto.response;
 
+import com.exchangediary.group.domain.entity.Group;
 import lombok.Builder;
 
 @Builder
 public record GroupIdResponse(
     Long groupId
 ) {
+    public static GroupIdResponse of(Group group) {
+        return GroupIdResponse.builder()
+                .groupId(group.getId())
+                .build();
+    }
 }

--- a/server/src/test/java/com/exchangediary/group/GroupCodeServiceTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCodeServiceTest.java
@@ -1,7 +1,6 @@
 package com.exchangediary.group;
 
 import com.exchangediary.global.exception.serviceexception.NotFoundException;
-import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.service.GroupCodeService;
 import com.exchangediary.group.service.GroupCommandService;
 import org.junit.jupiter.api.Test;
@@ -37,11 +36,11 @@ public class GroupCodeServiceTest {
     void 그룹_코드_검증_성공() {
         String code = "valid-code";
         when(groupCodeService.generateCode(any(String.class))).thenReturn(code);
-        Group group = groupCommandService.createGroup(GROUP_NAME);
+        Long groupId = groupCommandService.createGroup(GROUP_NAME).groupId();
 
-        Long groupId = groupCodeService.verifyCode(code);
+        Long result = groupCodeService.verifyCode(code);
 
-        assertThat(groupId).isEqualTo(group.getId());
+        assertThat(result).isEqualTo(groupId);
     }
 
     @Test

--- a/server/src/test/java/com/exchangediary/group/GroupCodeServiceTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCodeServiceTest.java
@@ -1,6 +1,6 @@
 package com.exchangediary.group;
 
-import com.exchangediary.global.exception.serviceexception.notfound.GroupNotFoundException;
+import com.exchangediary.global.exception.serviceexception.NotFoundException;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.service.GroupCodeService;
 import com.exchangediary.group.service.GroupCommandService;
@@ -49,7 +49,7 @@ public class GroupCodeServiceTest {
         groupCommandService.createGroup(GROUP_NAME);
         String code = "invalid-code";
 
-        GroupNotFoundException exception = assertThrows(GroupNotFoundException.class, () ->
+        NotFoundException exception = assertThrows(NotFoundException.class, () ->
             groupCodeService.verifyCode(code)
         );
 

--- a/server/src/test/java/com/exchangediary/group/GroupCodeTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCodeTest.java
@@ -40,26 +40,27 @@ public class GroupCodeTest {
     @Test
     void 그룹_코드_유효성_검증_성공() {
         String groupName = "버니즈";
-        Group group = groupCommandService.createGroup(groupName);
+        Long groupId = groupCommandService.createGroup(groupName).groupId();
+        Group group = groupRepository.findById(groupId).get();
         GroupCodeRequest groupCodeRequest = new GroupCodeRequest(group.getCode());
 
-        Long groupId = RestAssured
+        GroupIdResponse response = RestAssured
                 .given().log().all()
                 .body(groupCodeRequest)
                 .contentType(ContentType.JSON)
                 .when().post(API_PATH)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .extract().as(GroupIdResponse.class)
-                .groupId();
+                .extract().as(GroupIdResponse.class);
 
-        assertThat(groupId).isEqualTo(group.getId());
+        assertThat(response.groupId()).isEqualTo(group.getId());
     }
 
     @Test
     void 그룹_코드_유효성_검증_실패() {
         String groupName = "버니즈";
-        Group group = groupCommandService.createGroup(groupName);
+        Long groupId = groupCommandService.createGroup(groupName).groupId();
+        Group group = groupRepository.findById(groupId).get();
         GroupCodeRequest groupCodeRequest = new GroupCodeRequest(group.getCode() + "invalid");
 
         RestAssured

--- a/server/src/test/java/com/exchangediary/group/GroupCommandServiceTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCommandServiceTest.java
@@ -1,5 +1,7 @@
 package com.exchangediary.group;
 
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.service.GroupCodeService;
 import com.exchangediary.group.service.GroupCommandService;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,8 @@ class GroupCommandServiceTest {
     private GroupCommandService groupCommandService;
     @MockBean
     private GroupCodeService groupCodeService;
+    @Autowired
+    private GroupRepository groupRepository;
 
     @Test
     void 그룹_생성() {
@@ -30,6 +34,10 @@ class GroupCommandServiceTest {
         Long groupId = groupCommandService.createGroup(groupName).groupId();
 
         //then
-        assertThat(groupId).isEqualTo(1L);
+        Group group = groupRepository.findById(groupId).get();
+        assertThat(group.getName()).isEqualTo(groupName);
+        assertThat(group.getCode()).isEqualTo(code);
+        assertThat(group.getCurrentOrder()).isEqualTo(0);
+        assertThat(group.getNumberOfMembers()).isEqualTo(0);
     }
 }

--- a/server/src/test/java/com/exchangediary/group/GroupCommandServiceTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCommandServiceTest.java
@@ -1,6 +1,5 @@
 package com.exchangediary.group;
 
-import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.service.GroupCodeService;
 import com.exchangediary.group.service.GroupCommandService;
 import org.junit.jupiter.api.Test;
@@ -28,12 +27,9 @@ class GroupCommandServiceTest {
         when(groupCodeService.generateCode(groupName)).thenReturn(code);
 
         //when
-        Group createdGroup = groupCommandService.createGroup(groupName);
+        Long groupId = groupCommandService.createGroup(groupName).groupId();
 
         //then
-        assertThat(createdGroup.getName()).isEqualTo(groupName);
-        assertThat(createdGroup.getCode()).isEqualTo(code);
-        assertThat(createdGroup.getNumberOfMembers()).isEqualTo(0);
-        assertThat(createdGroup.getCurrentOrder()).isEqualTo(0);
+        assertThat(groupId).isEqualTo(1L);
     }
 }

--- a/server/src/test/java/com/exchangediary/group/GroupCreateTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCreateTest.java
@@ -45,6 +45,8 @@ public class GroupCreateTest {
                 .extract().as(GroupIdResponse.class)
                 .groupId();
 
-        assertThat(groupId).isEqualTo(1L);
+        // ToDo: 아래 부분 location으로 확인하도록 수정
+        String result = groupRepository.findById(groupId).get().getName();
+        assertThat(result).isEqualTo(groupName);
     }
 }

--- a/server/src/test/java/com/exchangediary/group/GroupCreateTest.java
+++ b/server/src/test/java/com/exchangediary/group/GroupCreateTest.java
@@ -1,0 +1,50 @@
+package com.exchangediary.group;
+
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.service.GroupCommandService;
+import com.exchangediary.group.ui.dto.request.GroupNameRequest;
+import com.exchangediary.group.ui.dto.response.GroupIdResponse;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GroupCreateTest {
+    private static final String API_PATH = "/api/groups";
+    @LocalServerPort
+    private int port;
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private GroupCommandService groupCommandService;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        groupRepository.deleteAllInBatch();;
+    }
+
+    @Test
+    void 그룹_생성_성공() {
+        String groupName = "버니즈";
+
+        Long groupId = RestAssured
+                .given().log().all()
+                .body(new GroupNameRequest(groupName))
+                .contentType(ContentType.JSON)
+                .when().post(API_PATH)
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().as(GroupIdResponse.class)
+                .groupId();
+
+        assertThat(groupId).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## Work Description
> 그룹 생성 API 개발

- 그룹 생성 API에 필요한 컨트롤러를 추가했습니다. 
- 구현되어있던 그룹 생성 서비스의 반환값을 dto로 수정했습니다. 
- 그룹 생성 성공 API에 대한 통합테스트를 구현했습니다. 

## ISSUE
- closed #140 


## Screenshot
<img width="440" alt="Screenshot 2024-10-03 at 3 12 06 AM" src="https://github.com/user-attachments/assets/3940e95c-3bb0-4ab2-a901-03de4deebdc1">

- 서비스 레이어 반환 타입이 수정됨에 따라서 테스트가 동작하도록 수정하였습니다. 
모두 통과하는 것을 확인할 수 있습니다.

## To Reviewers
컨트롤러에 도메인이 노출되는 것을 피하기 위해서 서비스 레이어의 반환값을 dto로 수정하였습니다. 
이 부분에 대한 다른 의견이 있다면 나누어봤으면 좋겠어요!
