### PR TITLE
업로드 이미지 엔티티 수정

### DIFF
--- a/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
@@ -38,6 +38,7 @@ public class UploadImage extends BaseEntity {
     private final byte[] image;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", foreignKey = @ForeignKey(name = "upload_image_diary_id_fkey"))
+    @NotNull
     private Diary diary;
 
     public void uploadToDiary(Diary diary) {

--- a/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
@@ -16,6 +16,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.type.descriptor.jdbc.LongVarbinaryJdbcType;
 
 import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
@@ -31,6 +33,7 @@ public class UploadImage extends BaseEntity {
     @Column(name = "upload_image_id")
     private Long id;
     @Lob
+    @JdbcType(LongVarbinaryJdbcType.class)
     @NotNull
     private final byte[] image;
     @OneToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## Work Description
> 업로드 이미지 엔티티 수정

- 업로드 이미지 엔티티의 image 필드 타입을 수정했습니다. https://github.com/Buddies2024/spring/blob/f8b49d221387ee29ff27de67ea822bb7d4176893/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java#L35-L38
  - 업로드 이미지 엔티티의 image 필드가 postgresql의 oid 타입으로 매핑되는데,
테스트 환경의 데이터베이스인 h2 데이터베이스가 oid 타입을 인지하지 못하는 문제를 발견했습니다. 
  - 따라서 @JdbcType 어노테이션의 LONGVARBINARY 타입을 갖도록 추가해주었습니다. 

- 업로드 이미지 엔티티의 diary 필드에 not null 제약조건을 추가했습니다. 
https://github.com/Buddies2024/spring/blob/f8b49d221387ee29ff27de67ea822bb7d4176893/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java#L39-L42


## ISSUE
- closed #164 


## Screenshot
#### 서비스 환경
<img width="984" alt="Screenshot 2024-10-08 at 4 18 37 PM" src="https://github.com/user-attachments/assets/53cbd724-fc01-4673-b1cc-8a213c44ddaf">

#### 테스트 환경
<img width="1152" alt="Screenshot 2024-10-08 at 4 16 26 PM" src="https://github.com/user-attachments/assets/4fa9bb13-5d51-48b7-b13f-00a90489cac5">

#### 테스트 성공
<img width="399" alt="Screenshot 2024-10-08 at 4 09 07 PM" src="https://github.com/user-attachments/assets/2e43d8f4-39f2-4259-9444-6a9a568ac31c">


## Reference
[Mybatis jdbctype(마이바티스 Jdbctype)](https://lts0606.tistory.com/615)