### PR TITLE
업로드 이미지 엔티티 오류 해결

### DIFF
--- a/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
@@ -38,7 +38,6 @@ public class UploadImage extends BaseEntity {
     private final byte[] image;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", foreignKey = @ForeignKey(name = "upload_image_diary_id_fkey"))
-    @NotNull
     private Diary diary;
 
     public void uploadToDiary(Diary diary) {


### PR DESCRIPTION
## Work Description
> 업로드 이미지 엔티티 오류 해결

- 업로드 이미지 엔티티의 diary 필드의 not null 제약조건 제거
  - 오류의 이유는 #170 참고

## ISSUE
- closed #170


## Screenshot
<img width="931" alt="Screenshot 2024-10-09 at 3 15 18 AM" src="https://github.com/user-attachments/assets/cdf87bcb-6b25-4b3e-9392-b815f16ea5d6">


## To Reviewers
- 이렇게 또 한 번 테스트 코드의 중요성을 느낀다...
일기 부분에도 얼른 테스트 코드 추가해야할 듯!!!