### PR TITLE
그룹 생성 API 수정

### DIFF
--- a/server/src/main/java/com/exchangediary/group/service/GroupCreateService.java
+++ b/server/src/main/java/com/exchangediary/group/service/GroupCreateService.java
@@ -2,7 +2,8 @@ package com.exchangediary.group.service;
 
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
-import com.exchangediary.group.ui.dto.response.GroupIdResponse;
+import com.exchangediary.group.ui.dto.request.GroupCreateRequest;
+import com.exchangediary.group.ui.dto.response.GroupCreateResponse;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.domain.entity.Member;
 import com.exchangediary.member.service.MemberQueryService;
@@ -19,10 +20,10 @@ public class GroupCreateService {
     private final MemberQueryService memberQueryService;
     private final MemberRepository memberRepository;
 
-    public GroupIdResponse createGroup(String groupName, Long memberId) {
-        Group group = saveGroup(groupName);
-        updateMember(memberId, group);
-        return GroupIdResponse.from(group.getId());
+    public GroupCreateResponse createGroup(GroupCreateRequest request, Long memberId) {
+        Group group = saveGroup(request.groupName());
+        updateMember(memberId, request, group);
+        return GroupCreateResponse.of(group);
     }
 
     private Group saveGroup(String groupName) {
@@ -30,9 +31,10 @@ public class GroupCreateService {
         return groupRepository.save(group);
     }
 
-    private void updateMember(Long memberId, Group group) {
+    private void updateMember(Long memberId, GroupCreateRequest request, Group group) {
         Member member = memberQueryService.findMember(memberId);
-        member.addGroup(group);
+        member.updateMemberGroupInfo(request.nickname(), request.profileLocation(), 1, group);
         memberRepository.save(member);
+
     }
 }

--- a/server/src/main/java/com/exchangediary/group/service/GroupJoinService.java
+++ b/server/src/main/java/com/exchangediary/group/service/GroupJoinService.java
@@ -27,7 +27,7 @@ public class GroupJoinService {
 
         String code = processGroupJoinOrCreate(group, request.profileLocation());
         int maxOrderInGroup = findMaxOrderInGroup(group.getMembers());
-        member.updateMemberGroupInfo(request, group, maxOrderInGroup + 1);
+//        member.updateMemberGroupInfo(request, group, maxOrderInGroup + 1);
         memberRepository.save(member);
         return GroupJoinResponse.from(code);
     }

--- a/server/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
+++ b/server/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
@@ -6,14 +6,16 @@ import com.exchangediary.group.service.GroupQueryService;
 import com.exchangediary.group.service.GroupCreateService;
 import com.exchangediary.group.ui.dto.request.GroupCodeRequest;
 import com.exchangediary.group.ui.dto.request.GroupJoinRequest;
-import com.exchangediary.group.ui.dto.request.GroupNameRequest;
+import com.exchangediary.group.ui.dto.request.GroupCreateRequest;
 import com.exchangediary.group.ui.dto.request.GroupNicknameRequest;
+import com.exchangediary.group.ui.dto.response.GroupCreateResponse;
 import com.exchangediary.group.ui.dto.response.GroupIdResponse;
 import com.exchangediary.group.ui.dto.response.GroupJoinResponse;
 import com.exchangediary.group.ui.dto.response.GroupNicknameVerifyResponse;
 import com.exchangediary.group.ui.dto.response.GroupProfileResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -37,14 +39,14 @@ public class ApiGroupController {
     private final GroupQueryService groupQueryService;
 
     @PostMapping
-    public ResponseEntity<GroupIdResponse> createGroup(
-            @RequestBody @Valid GroupNameRequest request,
+    public ResponseEntity<GroupCreateResponse> createGroup(
+            @RequestBody @Valid GroupCreateRequest request,
             @RequestAttribute Long memberId
     ) {
-        GroupIdResponse groupIdResponse = groupCreateService.createGroup(request.groupName(), memberId);
+        GroupCreateResponse response = groupCreateService.createGroup(request, memberId);
         return ResponseEntity
-                .created(URI.create("/api/groups/" + groupIdResponse.groupId()))
-                .body(groupIdResponse);
+                .status(HttpStatus.CREATED)
+                .body(response);
     }
 
     @PostMapping("/code/verify")

--- a/server/src/main/java/com/exchangediary/group/ui/dto/request/GroupCreateRequest.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/request/GroupCreateRequest.java
@@ -1,0 +1,10 @@
+package com.exchangediary.group.ui.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GroupCreateRequest(
+        @NotBlank String groupName,
+        @NotBlank String profileLocation,
+        @NotBlank String nickname
+) {
+}

--- a/server/src/main/java/com/exchangediary/group/ui/dto/request/GroupNameRequest.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/request/GroupNameRequest.java
@@ -1,8 +1,0 @@
-package com.exchangediary.group.ui.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record GroupNameRequest(
-        @NotBlank String groupName
-) {
-}

--- a/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupCreateResponse.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupCreateResponse.java
@@ -1,0 +1,17 @@
+package com.exchangediary.group.ui.dto.response;
+
+import com.exchangediary.group.domain.entity.Group;
+import lombok.Builder;
+
+@Builder
+public record GroupCreateResponse(
+        Long groupId,
+        String code
+) {
+    public static GroupCreateResponse of(Group group) {
+        return GroupCreateResponse.builder()
+                .groupId(group.getId())
+                .code(group.getCode())
+                .build();
+    }
+}

--- a/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupIdResponse.java
+++ b/server/src/main/java/com/exchangediary/group/ui/dto/response/GroupIdResponse.java
@@ -1,6 +1,5 @@
 package com.exchangediary.group.ui.dto.response;
 
-import com.exchangediary.group.domain.entity.Group;
 import lombok.Builder;
 
 @Builder

--- a/server/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/server/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -2,7 +2,6 @@ package com.exchangediary.member.domain.entity;
 
 import com.exchangediary.global.domain.entity.BaseEntity;
 import com.exchangediary.group.domain.entity.Group;
-import com.exchangediary.group.ui.dto.request.GroupJoinRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -40,13 +39,9 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "group_id", foreignKey = @ForeignKey(name = "member_group_id_fkey"))
     private Group group;
 
-    public void addGroup(Group group) {
-        this.group = group;
-    }
-
-    public void updateMemberGroupInfo(GroupJoinRequest request, Group group, int orderInGroup) {
-        this.nickname = request.nickname();
-        this.profileLocation = request.profileLocation();
+    public void updateMemberGroupInfo(String nickname, String profileLocation, int orderInGroup, Group group) {
+        this.nickname = nickname;
+        this.profileLocation = profileLocation;
         this.orderInGroup = orderInGroup;
         this.group = group;
     }

--- a/server/src/test/java/com/exchangediary/group/api/GroupCreateApiTest.java
+++ b/server/src/test/java/com/exchangediary/group/api/GroupCreateApiTest.java
@@ -3,12 +3,14 @@ package com.exchangediary.group.api;
 import com.exchangediary.ApiBaseTest;
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
-import com.exchangediary.group.ui.dto.request.GroupNameRequest;
-import com.exchangediary.group.ui.dto.response.GroupIdResponse;
+import com.exchangediary.group.ui.dto.request.GroupCreateRequest;
+import com.exchangediary.group.ui.dto.response.GroupCreateResponse;
 import com.exchangediary.member.domain.entity.Member;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
@@ -22,21 +24,57 @@ public class GroupCreateApiTest extends ApiBaseTest {
     @Test
     void 그룹_생성_성공() {
         String groupName = "버니즈";
+        String profileLocation = "/profile/location";
+        String nickname = "yen";
 
-        Long groupId = RestAssured
+        var response = RestAssured
                 .given().log().all()
-                .body(new GroupNameRequest(groupName))
+                .body(new GroupCreateRequest(groupName, profileLocation, nickname))
                 .cookie("token", token)
                 .contentType(ContentType.JSON)
                 .when().post(API_PATH)
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value())
-                .extract().as(GroupIdResponse.class)
-                .groupId();
+                .extract().as(GroupCreateResponse.class);
 
-        Group group = groupRepository.findById(groupId).get();
+        Group group = groupRepository.findById(response.groupId()).get();
         assertThat(group.getName()).isEqualTo(groupName);
         Member groupCreator = memberRepository.findById(member.getId()).get();
         assertThat(groupCreator.getGroup().getId()).isEqualTo(group.getId());
+        assertThat(groupCreator.getOrderInGroup()).isEqualTo(1);
+        assertThat(groupCreator.getNickname()).isEqualTo(nickname);
+        assertThat(groupCreator.getProfileLocation()).isEqualTo(profileLocation);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "    "})
+    void 그룹_생성_실패_빈_닉네임(String nickname) {
+        String groupName = "버니즈";
+        String profileLocation = "/profile/location";
+
+        RestAssured
+                .given().log().all()
+                .body(new GroupCreateRequest(groupName, profileLocation, nickname))
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .when().post(API_PATH)
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "    "})
+    void 그룹_생성_실패_빈_프로필_경로(String profileLocation) {
+        String groupName = "버니즈";
+        String nickname = "yen";
+
+        RestAssured
+                .given().log().all()
+                .body(new GroupCreateRequest(groupName, profileLocation, nickname))
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .when().post(API_PATH)
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }


### PR DESCRIPTION
## Work Description
> 그룹 생성 API 수정

- 그룹 생성 API를 수정했습니다. 
- 요청 시 그룹 정보(이름)과 사용자의 그룹 정보(닉네임, 프로필 이미지 경로)를 받습니다.
- 응답 시 생성된 그룹의 id와 코드가 반환됩니다.
- 테스트 수정 및 잘못된 요청에 대한 테스트를 추가했습니다.

## ISSUE
- closed #193


## Screenshot
<img width="428" alt="Screenshot 2024-10-12 at 7 46 15 PM" src="https://github.com/user-attachments/assets/d638184f-fab5-4d62-9ced-500f29e22cfa">

