### PR TITLE
프로필 이미지 선택 조회 API 수정

### DIFF
--- a/server/src/main/java/com/exchangediary/group/service/GroupQueryService.java
+++ b/server/src/main/java/com/exchangediary/group/service/GroupQueryService.java
@@ -32,7 +32,6 @@ public class GroupQueryService {
     public GroupProfileResponse viewSelectableProfileImage(Long groupId) {
         Group group = findGroup(groupId);
         List<Member> members = group.getMembers();
-        groupValidationService.checkNumberOfMembers(members.size());
         return GroupProfileResponse.from(members);
     }
 

--- a/server/src/test/java/com/exchangediary/group/api/GroupProfileApiTest.java
+++ b/server/src/test/java/com/exchangediary/group/api/GroupProfileApiTest.java
@@ -43,6 +43,46 @@ class GroupProfileApiTest extends ApiBaseTest {
     }
 
     @Test
+    void 프로필_이미지_선택_목록_조회_그룹원_없을때() {
+        Group group = createGroup();
+        groupRepository.save(group);
+
+        GroupProfileResponse response = RestAssured
+                .given().log().all()
+                .contentType(ContentType.JSON)
+                .cookie("token", token)
+                .when().get(String.format(API_PATH, group.getId()))
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(GroupProfileResponse.class);
+
+        assertThat(response.selectedImages()).hasSize(0);
+    }
+
+    @Test
+    void 프로필_이미지_선택_목록_조회_그룹원_다참() {
+        Group group = createGroup();
+        groupRepository.save(group);
+        List<Member> members = new ArrayList<>();
+        for (int i = 1; i <= 7; i++) {
+            members.add(createMember(group, i));
+        }
+        memberRepository.saveAll(members);
+
+        GroupProfileResponse response = RestAssured
+                .given().log().all()
+                .contentType(ContentType.JSON)
+                .cookie("token", token)
+                .when().get(String.format(API_PATH, group.getId()))
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(GroupProfileResponse.class);
+
+
+        assertThat(response.selectedImages()).hasSize(7);
+    }
+
+    @Test
     void 프로필_이미지_선택_목록_조회_그룹없음() {
         Long groupId = 100L;
 
@@ -53,25 +93,6 @@ class GroupProfileApiTest extends ApiBaseTest {
                 .when().get(String.format(API_PATH, groupId))
                 .then().log().all()
                 .statusCode(HttpStatus.NOT_FOUND.value());
-    }
-
-    @Test
-    void 프로필_이미지_선택_목록_조회_멤버_초과() {
-        Group group = createGroup();
-        groupRepository.save(group);
-        List<Member> members = new ArrayList<>();
-        for (int i = 1; i <= 7; i++) {
-            members.add(createMember(group, i));
-        }
-        memberRepository.saveAll(members);
-
-        RestAssured
-                .given().log().all()
-                .contentType(ContentType.JSON)
-                .cookie("token", token)
-                .when().get(String.format(API_PATH, group.getId()))
-                .then().log().all()
-                .statusCode(HttpStatus.CONFLICT.value());
     }
 
     private Member createMember(Group group, int index) {


### PR DESCRIPTION
## Work Description
> 프로필 이미지 선택 조회 API 수정

- 프로필 이미지 선택 조회 API에서 그룹 인원 초과 에외를 처리했던 것을 제거했습니다.
- 그룹원이 7명인 경우의 테스트명을 수정하고, 그룹원이 없는 경우에 대한 테스트를 추가했습니다.

## ISSUE
- closed #195


## Screenshot
<img width="416" alt="Screenshot 2024-10-12 at 7 58 02 PM" src="https://github.com/user-attachments/assets/49d878ac-124e-48dd-9fc6-52b66f32e879">
