### PR TITLE
그룹 역할 필드 추가

### DIFF
--- a/src/main/java/com/exchangediary/group/service/GroupCreateService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupCreateService.java
@@ -6,6 +6,7 @@ import com.exchangediary.group.ui.dto.request.GroupCreateRequest;
 import com.exchangediary.group.ui.dto.response.GroupCreateResponse;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
 import com.exchangediary.member.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,7 +34,7 @@ public class GroupCreateService {
 
     private void updateMember(Long memberId, GroupCreateRequest request, Group group) {
         Member member = memberQueryService.findMember(memberId);
-        member.updateMemberGroupInfo(request.nickname(), request.profileImage(), 1, group);
+        member.updateMemberGroupInfo(request.nickname(), request.profileImage(), 1, GroupRole.GROUP_LEADER, group);
         memberRepository.save(member);
     }
 }

--- a/src/main/java/com/exchangediary/group/service/GroupJoinService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupJoinService.java
@@ -4,6 +4,7 @@ import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.ui.dto.request.GroupJoinRequest;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
 import com.exchangediary.member.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,7 @@ public class GroupJoinService {
                 request.nickname(),
                 request.profileImage(),
                 members.size() + 1,
+                GroupRole.GROUP_MEMBER,
                 group);
         memberRepository.save(member);
     }

--- a/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -2,8 +2,11 @@ package com.exchangediary.member.domain.entity;
 
 import com.exchangediary.global.domain.entity.BaseEntity;
 import com.exchangediary.group.domain.entity.Group;
+import com.exchangediary.member.domain.enums.GroupRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -35,14 +38,23 @@ public class Member extends BaseEntity {
     private String nickname;
     private String profileImage;
     private Integer orderInGroup;
+    @Enumerated(EnumType.STRING)
+    private GroupRole groupRole;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id", foreignKey = @ForeignKey(name = "member_group_id_fkey"))
     private Group group;
 
-    public void updateMemberGroupInfo(String nickname, String profileImage, int orderInGroup, Group group) {
+    public void updateMemberGroupInfo(
+            String nickname,
+            String profileImage,
+            int orderInGroup,
+            GroupRole groupRole,
+            Group group
+    ) {
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.orderInGroup = orderInGroup;
+        this.groupRole = groupRole;
         this.group = group;
     }
 }

--- a/src/main/java/com/exchangediary/member/domain/enums/GroupRole.java
+++ b/src/main/java/com/exchangediary/member/domain/enums/GroupRole.java
@@ -1,0 +1,6 @@
+package com.exchangediary.member.domain.enums;
+
+public enum GroupRole {
+    GROUP_LEADER,
+    GROUP_MEMBER
+}

--- a/src/test/java/com/exchangediary/diary/api/DiaryCreateApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryCreateApiTest.java
@@ -7,6 +7,7 @@ import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
@@ -35,7 +36,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         Map<String, String> data = new HashMap<>();
         data.put("content", "buddies");
@@ -69,7 +70,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_내용만() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         Map<String, String> data = new HashMap<>();
         data.put("content", "buddies");
@@ -127,7 +128,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_순서_확인() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         Member groupMember2 = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));
@@ -166,7 +167,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_순서_확인_맨_첫_순서로() throws JsonProcessingException {
         Group group = createGroup(3);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 3, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 3, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         Member groupMember2 = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));
@@ -205,7 +206,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_순서_확인_내용만() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         Member groupMember2 = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));

--- a/src/test/java/com/exchangediary/diary/api/DiaryWritableStatusApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryWritableStatusApiTest.java
@@ -7,6 +7,7 @@ import com.exchangediary.diary.ui.dto.response.DiaryWritableStatusResponse;
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 내_순서_오늘_일기_작성_완료() {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         Diary diary = createDiary(group, member);
         diaryRepository.save(diary);
@@ -50,7 +51,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 내_순서_오늘_일기_작성_미완료() {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
 
         DiaryWritableStatusResponse response = RestAssured
@@ -70,7 +71,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 친구_순서_오늘_일기_작성_완료() {
         Group group = createGroup(2);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember));
         Diary diary = createDiary(group, groupMember);
@@ -93,7 +94,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 친구_순서_오늘_일기_작성_미완료() {
         Group group = createGroup(2);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, group);
+        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember));
 

--- a/src/test/java/com/exchangediary/group/api/GroupCreateApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupCreateApiTest.java
@@ -6,6 +6,7 @@ import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.ui.dto.request.GroupCreateRequest;
 import com.exchangediary.group.ui.dto.response.GroupCreateResponse;
 import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,7 @@ public class GroupCreateApiTest extends ApiBaseTest {
         assertThat(groupCreator.getOrderInGroup()).isEqualTo(1);
         assertThat(groupCreator.getNickname()).isEqualTo(nickname);
         assertThat(groupCreator.getProfileImage()).isEqualTo(profileImage);
+        assertThat(groupCreator.getGroupRole()).isEqualTo(GroupRole.GROUP_LEADER);
     }
 
     @ParameterizedTest

--- a/src/test/java/com/exchangediary/group/api/GroupJoinApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupJoinApiTest.java
@@ -6,6 +6,7 @@ import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.ui.dto.request.GroupJoinRequest;
 import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,7 @@ class GroupJoinApiTest extends ApiBaseTest {
         assertThat(updatedMember.getProfileImage()).isEqualTo("orange");
         assertThat(updatedMember.getOrderInGroup()).isEqualTo(2);
         assertThat(updatedMember.getGroup().getId()).isEqualTo(group.getId());
+        assertThat(updatedMember.getGroupRole()).isEqualTo(GroupRole.GROUP_MEMBER);
     }
 
     @Test

--- a/src/test/java/com/exchangediary/group/api/GroupMembersOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupMembersOrderApiTest.java
@@ -6,6 +6,7 @@ import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.ui.dto.response.GroupMembersResponse;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +28,7 @@ public class GroupMembersOrderApiTest extends ApiBaseTest {
     void 그룹원_순서_조회_내순서_1번일때() {
         Group group = createGroup();
         groupRepository.save(group);
-        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 1, group);
+        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         for (int idx = 6; idx > 0; idx--) {
             Member member = createMember(group, idx + 1, PROFILE_IMAGES.get(7 - idx));
@@ -59,7 +60,7 @@ public class GroupMembersOrderApiTest extends ApiBaseTest {
     void 그룹원_순서_조회_내순서_4번일때() {
         Group group = createGroup();
         groupRepository.save(group);
-        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 4, group);
+        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 4, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         for (int idx = 3; idx > 0; idx--) {
             Member member = createMember(group, idx, PROFILE_IMAGES.get(7 - idx));
@@ -95,7 +96,7 @@ public class GroupMembersOrderApiTest extends ApiBaseTest {
     void 그룹원_순서_조회_내순서_7번일때() {
         Group group = createGroup();
         groupRepository.save(group);
-        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 7, group);
+        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 7, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         for (int idx = 6; idx > 0; idx--) {
             Member member = createMember(group, idx, PROFILE_IMAGES.get(7 - idx));


### PR DESCRIPTION
## Work Description
> 그룹 역할 필드 추가

- 그룹 역할(GroupRole) enum을 생성했습니다.
```java
public enum GroupRole {
    GROUP_LEADER, // 그룹장
    GROUP_MEMBER  // 그룹원
}
```
- 멤버 엔티티에 그룹 역할 필드를 추가했습니다.
- 그룹 생성 시 사용자의 그룹 역할은 그룹장(`GROUP_LEADER`)이고, 
그룹 가입 시 사용자의 그룹 역할은 그룹원(`GROUP_MEMBER`)입니다.
- 그룹 생성, 가입 성공 테스트에서 그룹 역할 확인 검증을 추가했습니다.

## ISSUE
- closed #237 
- closed #238


## Screenshot
#### 테스트 결과
<img width="422" alt="Screenshot 2024-10-20 at 3 08 58 AM" src="https://github.com/user-attachments/assets/560303ff-398d-4200-8f34-64ac99716a2a">
<img width="422" alt="Screenshot 2024-10-20 at 3 09 20 AM" src="https://github.com/user-attachments/assets/33cd3a97-21d9-40fa-b741-299353b4688c">
<img width="430" alt="Screenshot 2024-10-20 at 3 08 29 AM" src="https://github.com/user-attachments/assets/8b4de2f0-00b7-4aae-a74e-503307b67da3">


