### PR TITLE
일기 작성 상태 조회 api 수정 - 볼 수 있는 일기id 값 반환

### DIFF
--- a/src/main/java/com/exchangediary/diary/domain/DiaryRepository.java
+++ b/src/main/java/com/exchangediary/diary/domain/DiaryRepository.java
@@ -12,4 +12,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findAllByGroupYearAndMonth(Long groupId, int year, int month);
     @Query("SELECT d.id FROM Diary d WHERE d.group.id = :groupId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month AND DAY(d.createdAt) = :day")
     Optional<Long> findIdByGroupAndDate(Long groupId, int year, int month, int day);
+    @Query("SELECT d.id FROM Diary d WHERE d.group.id = :groupId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month AND DAY(d.createdAt) = :day")
+    Optional<Diary> findByGroupAndDate(Long groupId, int year, int month, int day);
 }

--- a/src/main/java/com/exchangediary/diary/domain/DiaryRepository.java
+++ b/src/main/java/com/exchangediary/diary/domain/DiaryRepository.java
@@ -12,6 +12,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findAllByGroupYearAndMonth(Long groupId, int year, int month);
     @Query("SELECT d.id FROM Diary d WHERE d.group.id = :groupId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month AND DAY(d.createdAt) = :day")
     Optional<Long> findIdByGroupAndDate(Long groupId, int year, int month, int day);
-    @Query("SELECT d.id FROM Diary d WHERE d.group.id = :groupId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month AND DAY(d.createdAt) = :day")
+    @Query("SELECT d FROM Diary d WHERE d.group.id = :groupId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month AND DAY(d.createdAt) = :day")
     Optional<Diary> findByGroupAndDate(Long groupId, int year, int month, int day);
 }

--- a/src/main/java/com/exchangediary/diary/service/DiaryCommandService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryCommandService.java
@@ -84,7 +84,10 @@ public class DiaryCommandService {
         LocalDate today = LocalDate.now();
         Optional<Long> todayDiary =
                 diaryRepository.findIdByGroupAndDate(
-                        groupId, today.getYear(), today.getMonthValue(), today.getDayOfMonth());
+                        groupId,
+                        today.getYear(),
+                        today.getMonthValue(),
+                        today.getDayOfMonth());
 
         if (todayDiary.isPresent()) {
             throw new DuplicateException(

--- a/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
@@ -69,7 +69,7 @@ public class DiaryQueryService {
         Optional<Diary> todayDiary = findTodayDiary(groupId);
         if (todayDiary.isPresent()) {
             writtenTodayDiary = true;
-            diaryId = getViewableDiaryId(isMyOrder, writtenTodayDiary, memberId, todayDiary.get());
+            diaryId = getTodayDiaryId(isMyOrder, memberId, todayDiary.get());
         }
         return DiaryWritableStatusResponse.of(isMyOrder, writtenTodayDiary, diaryId);
     }
@@ -97,27 +97,25 @@ public class DiaryQueryService {
     private Boolean isCurrentOrder(Long groupId, Long memberId) {
         Group group = groupQueryService.findGroup(groupId);
         Member member = memberQueryService.findMember(memberId);
-        return group.getCurrentOrder() == member.getOrderInGroup();
+        return group.getCurrentOrder().equals(member.getOrderInGroup());
     }
 
     private Optional<Diary> findTodayDiary(Long groupId) {
         LocalDate today = LocalDate.now();
-        Optional<Diary> todayDiary =
-                diaryRepository.findByGroupAndDate(
-                        groupId, today.getYear(), today.getMonthValue(), today.getDayOfMonth());
+        Optional<Diary> todayDiary = diaryRepository.findByGroupAndDate(
+                groupId,
+                today.getYear(),
+                today.getMonthValue(),
+                today.getDayOfMonth());
         return todayDiary;
     }
 
-    private Long getViewableDiaryId(
-            Boolean isMyOrder,
-            Boolean writtenTodayDiary,
-            Long memberId,
-            Diary todayDiary
+    private Long getTodayDiaryId(Boolean isMyOrder, Long memberId, Diary todayDiary
     ) {
         if (todayDiary.getMember().getId().equals(memberId)) {
             return todayDiary.getId();
         }
-        if (isMyOrder && writtenTodayDiary) {
+        if (isMyOrder) {
             return todayDiary.getId();
         }
         return null;

--- a/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
@@ -63,13 +63,14 @@ public class DiaryQueryService {
 
     public DiaryWritableStatusResponse getDiaryWritableStatus(Long groupId, Long memberId) {
         Boolean writtenTodayDiary = false;
+        Long diaryId = null;
 
         Boolean isMyOrder = isCurrentOrder(groupId, memberId);
         Optional<Diary> todayDiary = findTodayDiary(groupId);
         if (todayDiary.isPresent()) {
             writtenTodayDiary = true;
+            diaryId = getViewableDiaryId(isMyOrder, writtenTodayDiary, memberId, todayDiary.get());
         }
-        Long diaryId = getViewableDiaryId(isMyOrder, writtenTodayDiary, memberId, todayDiary.get());
         return DiaryWritableStatusResponse.of(isMyOrder, writtenTodayDiary, diaryId);
     }
 

--- a/src/main/java/com/exchangediary/diary/ui/dto/response/DiaryWritableStatusResponse.java
+++ b/src/main/java/com/exchangediary/diary/ui/dto/response/DiaryWritableStatusResponse.java
@@ -5,12 +5,14 @@ import lombok.Builder;
 @Builder
 public record DiaryWritableStatusResponse(
         Boolean isMyOrder,
-        Boolean writtenTodayDiary
+        Boolean writtenTodayDiary,
+        Long viewableDiaryId
 ) {
-    public static DiaryWritableStatusResponse of(Boolean isMyOrder, Boolean writtenTodayDiary) {
+    public static DiaryWritableStatusResponse of(Boolean isMyOrder, Boolean writtenTodayDiary, Long diaryId) {
         return DiaryWritableStatusResponse.builder()
                 .isMyOrder(isMyOrder)
                 .writtenTodayDiary(writtenTodayDiary)
+                .viewableDiaryId(diaryId)
                 .build();
     }
 }


### PR DESCRIPTION
## Work Description
> 일기 작성 상태 조회 api 수정 - 볼 수 있는 일기id 값 반환

- 볼 수 있는 일기에 대해 일기 id 값 반환 해줌

## ISSUE
- closed #276 


## Screenshot
<img width="700" alt="스크린샷 2024-10-22 오전 3 52 10" src="https://github.com/user-attachments/assets/f74dc354-22db-4326-9e3b-452b887af217">


- 케이스1에 해당하는 테스트 일기 id 반환값 확인, 내가 오늘 일기 작성한 경우 테스트 추가해주었습니다.
<img width="369" alt="스크린샷 2024-10-22 오전 3 53 21" src="https://github.com/user-attachments/assets/6745b834-8395-483f-9648-c9818f749857">
