### PR TITLE
일기 순서 넘기기 API 구현

### DIFF
--- a/src/main/java/com/exchangediary/diary/service/DiaryCommandService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryCommandService.java
@@ -104,9 +104,7 @@ public class DiaryCommandService {
 
     private void changeCurrentOrderOfGroup(Group group) {
         int currentOrder = group.getCurrentOrder() + 1;
-        if (group.getMembers().size() < currentOrder)
-            currentOrder = 1;
-        group.updateCurrentOrder(currentOrder);
+        group.updateCurrentOrder(currentOrder, group.getMembers().size());
         groupRepository.save(group);
     }
 

--- a/src/main/java/com/exchangediary/global/exception/ErrorCode.java
+++ b/src/main/java/com/exchangediary/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."),
 
     FULL_MEMBERS_OF_GROUP(HttpStatus.CONFLICT, "그룹원이 꽉 차\n해당 그룹에 들어갈 수 없습니다."),
+    ALREADY_SKIP_ORDER_TODAY(HttpStatus.CONFLICT, "일기 건너뛰기는 하루에 한 번만 가능합니다."),
 
     INVALID_IMAGE_FORMAT(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 형식입니다."),
 

--- a/src/main/java/com/exchangediary/global/exception/ErrorCode.java
+++ b/src/main/java/com/exchangediary/global/exception/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."),
 
     FULL_MEMBERS_OF_GROUP(HttpStatus.CONFLICT, "그룹원이 꽉 차\n해당 그룹에 들어갈 수 없습니다."),
-    ALREADY_SKIP_ORDER_TODAY(HttpStatus.CONFLICT, "일기 건너뛰기는 하루에 한 번만 가능합니다."),
+    ALREADY_SKIP_ORDER_TODAY(HttpStatus.CONFLICT, "이미 한 번 건너뛰었어요!\n내일 다시 건너뛸 수 있어요."),
 
     INVALID_IMAGE_FORMAT(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 형식입니다."),
 

--- a/src/main/java/com/exchangediary/group/domain/entity/Group.java
+++ b/src/main/java/com/exchangediary/group/domain/entity/Group.java
@@ -52,7 +52,10 @@ public class Group extends BaseEntity {
                 .build();
     }
 
-    public void updateCurrentOrder(Integer currentOrder) {
+    public void updateCurrentOrder(int currentOrder, int numberOfMembers) {
+        if (currentOrder > numberOfMembers) {
+            currentOrder = 1;
+        }
         this.currentOrder = currentOrder;
     }
 }

--- a/src/main/java/com/exchangediary/group/domain/entity/Group.java
+++ b/src/main/java/com/exchangediary/group/domain/entity/Group.java
@@ -58,4 +58,8 @@ public class Group extends BaseEntity {
         }
         this.currentOrder = currentOrder;
     }
+
+    public void updateLastSkipOrderDate() {
+        this.lastSkipOrderDate = LocalDate.now();
+    }
 }

--- a/src/main/java/com/exchangediary/group/domain/entity/Group.java
+++ b/src/main/java/com/exchangediary/group/domain/entity/Group.java
@@ -15,6 +15,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static lombok.AccessLevel.PRIVATE;
@@ -36,15 +37,18 @@ public class Group extends BaseEntity {
     private Integer currentOrder;
     @NotNull
     private String code;
+    @NotNull
+    private LocalDate lastSkipOrderDate;
     @OneToMany(mappedBy = "group")
     @OrderBy("order_in_group ASC")
     private List<Member> members;
 
-    public static Group of(String groupName, String code) {
+    public static Group of(String groupName, String code, LocalDate lastSkipOrderDate) {
         return Group.builder()
                 .name(groupName)
                 .currentOrder(1)
                 .code(code)
+                .lastSkipOrderDate(lastSkipOrderDate)
                 .build();
     }
 

--- a/src/main/java/com/exchangediary/group/service/GroupCreateService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupCreateService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -28,7 +30,7 @@ public class GroupCreateService {
     }
 
     private Group saveGroup(String groupName) {
-        Group group = Group.of(groupName, groupCodeService.generateCode(groupName));
+        Group group = Group.of(groupName, groupCodeService.generateCode(groupName), LocalDate.now().minusDays(1));
         return groupRepository.save(group);
     }
 

--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -30,6 +30,7 @@ public class GroupLeaderService {
         Group group = groupQueryService.findGroup(groupId);
         groupValidationService.checkSkipOrderAuthority(group);
         group.updateCurrentOrder(group.getCurrentOrder() + 1, group.getMembers().size());
+        group.updateLastSkipOrderDate();
     }
 
     private Member findGroupMemberByIndex(Group group, int index) {

--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class GroupLeaderService {
     private final GroupQueryService groupQueryService;
+    private final GroupValidationService groupValidationService;
 
     public void handOverGroupLeader(Long groupId, Long memberId, GroupLeaderHandOverRequest request) {
         Group group = groupQueryService.findGroup(groupId);
@@ -23,6 +24,17 @@ public class GroupLeaderService {
 
         currentLeader.changeGroupRole(GroupRole.GROUP_MEMBER);
         newLeader.changeGroupRole(GroupRole.GROUP_LEADER);
+    }
+
+    public void skipDiaryOrder(Long groupId) {
+        Group group = groupQueryService.findGroup(groupId);
+        groupValidationService.checkSkipOrderAuthority(group);
+
+        int order = group.getCurrentOrder() + 1;
+        if (order > group.getMembers().size()) {
+            order = 1;
+        }
+        group.updateCurrentOrder(order);
     }
 
     private Member findGroupMemberByIndex(Group group, int index) {

--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -29,12 +29,7 @@ public class GroupLeaderService {
     public void skipDiaryOrder(Long groupId) {
         Group group = groupQueryService.findGroup(groupId);
         groupValidationService.checkSkipOrderAuthority(group);
-
-        int order = group.getCurrentOrder() + 1;
-        if (order > group.getMembers().size()) {
-            order = 1;
-        }
-        group.updateCurrentOrder(order);
+        group.updateCurrentOrder(group.getCurrentOrder() + 1, group.getMembers().size());
     }
 
     private Member findGroupMemberByIndex(Group group, int index) {

--- a/src/main/java/com/exchangediary/group/service/GroupValidationService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupValidationService.java
@@ -3,9 +3,11 @@ package com.exchangediary.group.service;
 import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.global.exception.serviceexception.ConfilctException;
 import com.exchangediary.global.exception.serviceexception.DuplicateException;
+import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.member.domain.entity.Member;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -38,6 +40,16 @@ public class GroupValidationService {
                     ErrorCode.PROFILE_DUPLICATED,
                     "",
                     profileImage
+            );
+        }
+    }
+
+    public void checkSkipOrderAuthority(Group group) {
+        if (group.getLastSkipOrderDate().isEqual(LocalDate.now())) {
+            throw new ConfilctException(
+                    ErrorCode.ALREADY_SKIP_ORDER_TODAY,
+                    "",
+                    LocalDate.now().toString()
             );
         }
     }

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/group/{groupId}/leader")
+@RequestMapping("/api/groups/{groupId}/leader")
 @RequiredArgsConstructor
 public class ApiGroupLeaderController {
     private final GroupLeaderService groupLeaderService;

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
@@ -29,4 +29,11 @@ public class ApiGroupLeaderController {
                 .build();
     }
 
+    @PatchMapping("/skip-order")
+    public ResponseEntity<Void> skipDiaryOrder(@PathVariable Long groupId) {
+        groupLeaderService.skipDiaryOrder(groupId);
+        return ResponseEntity
+                .ok()
+                .build();
+    }
 }

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
+import java.time.LocalDate;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GroupLeaderHandOverApiTest extends ApiBaseTest {
@@ -58,7 +60,7 @@ public class GroupLeaderHandOverApiTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return groupRepository.save(Group.of("group-name", "code"));
+        return groupRepository.save(Group.of("group-name", "code", LocalDate.now().minusDays(1)));
     }
 
     private void updateSelf(Group group, int order, GroupRole role) {

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
@@ -34,7 +34,7 @@ public class GroupLeaderHandOverApiTest extends ApiBaseTest {
                 .cookie("token", token)
                 .contentType(ContentType.JSON)
                 .body(new GroupLeaderHandOverRequest(member.getOrderInGroup() - 1))
-                .when().patch(String.format("/api/group/%s/leader/hand-over", group.getId()))
+                .when().patch(String.format("/api/groups/%s/leader/hand-over", group.getId()))
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 
@@ -54,7 +54,7 @@ public class GroupLeaderHandOverApiTest extends ApiBaseTest {
                 .cookie("token", token)
                 .contentType(ContentType.JSON)
                 .body(new GroupLeaderHandOverRequest(1))
-                .when().patch(String.format("/api/group/%s/leader/hand-over", group.getId()))
+                .when().patch(String.format("/api/groups/%s/leader/hand-over", group.getId()))
                 .then().log().all()
                 .statusCode(HttpStatus.NOT_FOUND.value());
     }

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
@@ -1,0 +1,83 @@
+package com.exchangediary.group.api;
+
+import com.exchangediary.ApiBaseTest;
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.domain.entity.Group;
+import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Test
+    void 일기_건너뛰기_성공() {
+        Group group = createGroup(2, LocalDate.now().minusDays(1));
+        updateSelf(group, 1, GroupRole.GROUP_LEADER);
+        createMember(group, 2, GroupRole.GROUP_MEMBER);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().patch("/api/group/" + group.getId() + "/leader/skip-order")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        int result = groupRepository.findById(group.getId()).get().getCurrentOrder();
+        assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    void 일기_건너뛰기_실패_오늘_이미_실행() {
+        Group group = createGroup(2, LocalDate.now());
+        updateSelf(group, 1, GroupRole.GROUP_LEADER);
+        createMember(group, 2, GroupRole.GROUP_MEMBER);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().patch("/api/group/" + group.getId() + "/leader/skip-order")
+                .then().log().all()
+                .statusCode(HttpStatus.CONFLICT.value());
+
+        int result = groupRepository.findById(group.getId()).get().getCurrentOrder();
+        assertThat(result).isEqualTo(2);
+    }
+
+    private Group createGroup(int order, LocalDate lastDate) {
+        Group group = Group.of("group-name", "code", lastDate);
+        group.updateCurrentOrder(order);
+        return groupRepository.save(group);
+    }
+
+    private void updateSelf(Group group, int order, GroupRole role) {
+        this.member.updateMemberGroupInfo(
+                "me",
+                "red",
+                order,
+                role,
+                group
+        );
+        memberRepository.save(this.member);
+    }
+
+    private Member createMember(Group group, int order, GroupRole role) {
+        return memberRepository.save(Member.builder()
+                .kakaoId(1L)
+                .nickname("group-member")
+                .profileImage("orange")
+                .orderInGroup(order)
+                .group(group)
+                .groupRole(role)
+                .build()
+        );
+    }
+}

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
@@ -1,6 +1,7 @@
 package com.exchangediary.group.api;
 
 import com.exchangediary.ApiBaseTest;
+import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.member.domain.entity.Member;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
     @Autowired
@@ -52,7 +54,9 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
                 .cookie("token", token)
                 .when().patch("/api/group/" + group.getId() + "/leader/skip-order")
                 .then().log().all()
-                .statusCode(HttpStatus.CONFLICT.value());
+                .statusCode(HttpStatus.CONFLICT.value())
+                .body("message", equalTo(ErrorCode.ALREADY_SKIP_ORDER_TODAY.getMessage()));
+        ;
 
         Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedGroup.getCurrentOrder()).isEqualTo(1);

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
@@ -29,7 +29,7 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
         RestAssured
                 .given().log().all()
                 .cookie("token", token)
-                .when().patch("/api/group/" + group.getId() + "/leader/skip-order")
+                .when().patch(String.format("/api/groups/%s/leader/skip-order", group.getId()))
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 
@@ -47,12 +47,12 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
         RestAssured
                 .given().log().all()
                 .cookie("token", token)
-                .when().patch("/api/group/" + group.getId() + "/leader/skip-order")
+                .when().patch(String.format("/api/groups/%s/leader/skip-order", group.getId()))
                 .then().log().all();
         RestAssured
                 .given().log().all()
                 .cookie("token", token)
-                .when().patch("/api/group/" + group.getId() + "/leader/skip-order")
+                .when().patch(String.format("/api/groups/%s/leader/skip-order", group.getId()))
                 .then().log().all()
                 .statusCode(HttpStatus.CONFLICT.value())
                 .body("message", equalTo(ErrorCode.ALREADY_SKIP_ORDER_TODAY.getMessage()));

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
@@ -54,7 +54,7 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
 
     private Group createGroup(int order, LocalDate lastDate) {
         Group group = Group.of("group-name", "code", lastDate);
-        group.updateCurrentOrder(order);
+        group.updateCurrentOrder(order, 2);
         return groupRepository.save(group);
     }
 


### PR DESCRIPTION
## Work Description
> 일기 순서 넘기기 API 구현

- 일기 순서 넘기기 API를 구현했습니다.
- 하루에 한 번 넘게 실행되는지 확인하기 위해서 Group 엔티티에 lastSkipOrderDate 필드를 추가했습니다.
  - 마지막으로 일기 건너뛰기 권한을 실행한 날짜를 의미합니다.
- 성공, 실패의 경우에 대해 각각 테스트를 추가했습니다.
  - 추후 방장 권한 인가 기능이 생기면 해당 테스트도 추가하도록 하겠습니다. 

## ISSUE
- closed #239


## Screenshot
#### 테스트 결과
<img width="453" alt="Screenshot 2024-10-23 at 1 21 41 AM" src="https://github.com/user-attachments/assets/886ebbfe-1e39-4bf7-adb8-f964eee97cd0">


## To Reviewers
- 일기 건너뛰기이지만 `skip order`을 사용한 이유는,
엄밀히 말하면 일기 순서를 건너뛰는(넘기는) 기능을 하는 API로 현재 저희 서비스 내에서 `order` 이라는 단어가 그룹 내 순서, 일기 작성 순서를 의미하고 있기 때문입니다.

