### PR TITLE
일기 서비스 리팩터링

### DIFF
--- a/src/main/java/com/exchangediary/diary/domain/entity/Diary.java
+++ b/src/main/java/com/exchangediary/diary/domain/entity/Diary.java
@@ -39,28 +39,24 @@ public class Diary extends BaseEntity {
     @Lob
     @JdbcType(LongVarcharJdbcType.class)
     @NotNull
-    private String content;
+    private final String content;
     @NotNull
-    private String moodLocation;
+    private final String moodLocation;
     @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL)
-    private UploadImage uploadImage;
+    private final UploadImage uploadImage;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member member;
+    private final Member member;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
-    private Group group;
+    private final Group group;
 
-    public static Diary of(DiaryRequest diaryRequest, UploadImage uploadImage) {
+    public static Diary from(DiaryRequest diaryRequest, Member member, Group group) {
         return Diary.builder()
                 .content(diaryRequest.content())
                 .moodLocation(diaryRequest.moodLocation())
-                .uploadImage(uploadImage)
+                .member(member)
+                .group(group)
                 .build();
-    }
-
-    public void addMemberAndGroup(Member member, Group group) {
-        this.member = member;
-        this.group = group;
     }
 }

--- a/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
+++ b/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
@@ -38,9 +38,12 @@ public class UploadImage extends BaseEntity {
     private final byte[] image;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", foreignKey = @ForeignKey(name = "upload_image_diary_id_fkey"))
-    private Diary diary;
+    private final Diary diary;
 
-    public void uploadToDiary(Diary diary) {
-        this.diary = diary;
+    public static UploadImage of(byte[] image, Diary diary) {
+        return UploadImage.builder()
+                .image(image)
+                .diary(diary)
+                .build();
     }
 }

--- a/src/main/java/com/exchangediary/diary/service/DiaryCommandService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryCommandService.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Transactional
 public class DiaryCommandService {
-
     private final MemberQueryService memberQueryService;
     private final GroupQueryService groupQueryService;
     private final DiaryValidationService diaryValidationService;

--- a/src/main/java/com/exchangediary/diary/service/DiaryCommandService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryCommandService.java
@@ -5,7 +5,6 @@ import com.exchangediary.diary.domain.entity.Diary;
 import com.exchangediary.diary.domain.entity.UploadImage;
 import com.exchangediary.diary.ui.dto.request.DiaryRequest;
 import com.exchangediary.global.exception.ErrorCode;
-import com.exchangediary.global.exception.serviceexception.DuplicateException;
 import com.exchangediary.global.exception.serviceexception.FailedImageUploadException;
 import com.exchangediary.global.exception.serviceexception.ForbiddenException;
 import com.exchangediary.group.domain.GroupRepository;
@@ -19,30 +18,22 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.time.LocalDate;
-import java.util.Optional;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class DiaryCommandService {
-    private static final Set<String> VALID_IMAGE_FORMAT = Set.of(
-            "image/jpeg",
-            "image/gif",
-            "image/png",
-            "image/heic",
-            "image/heif"
-    );
-    private final DiaryRepository diaryRepository;
+
     private final MemberQueryService memberQueryService;
     private final GroupQueryService groupQueryService;
+    private final DiaryValidationService diaryValidationService;
+    private final DiaryRepository diaryRepository;
     private final GroupRepository groupRepository;
 
     public Long createDiary(DiaryRequest diaryRequest, MultipartFile file, Long groupId, Long memberId) {
         Member member = memberQueryService.findMember(memberId);
         Group group = groupQueryService.findGroup(groupId);
-        checkTodayDiaryExistent(groupId);
+        diaryValidationService.checkTodayDiaryExistent(groupId);
         //Todo: 일기 작성 인가 후 삭제
         if (!member.getOrderInGroup().equals(group.getCurrentOrder())) {
             throw new ForbiddenException(
@@ -60,7 +51,7 @@ public class DiaryCommandService {
             return savedDiary.getId();
         }
 
-        validateImageType(file);
+        diaryValidationService.validateImageType(file);
         try {
             UploadImage image = UploadImage.builder()
                     .image(file.getBytes())
@@ -80,24 +71,6 @@ public class DiaryCommandService {
         }
     }
 
-    private void checkTodayDiaryExistent(Long groupId) {
-        LocalDate today = LocalDate.now();
-        Optional<Long> todayDiary =
-                diaryRepository.findIdByGroupAndDate(
-                        groupId,
-                        today.getYear(),
-                        today.getMonthValue(),
-                        today.getDayOfMonth());
-
-        if (todayDiary.isPresent()) {
-            throw new DuplicateException(
-                    ErrorCode.DIARY_DUPLICATED,
-                    "",
-                    today.toString()
-            );
-        }
-    }
-
     private boolean isEmptyFile(MultipartFile file) {
         return file == null || file.isEmpty();
     }
@@ -108,17 +81,5 @@ public class DiaryCommandService {
             currentOrder = 1;
         group.updateCurrentOrder(currentOrder);
         groupRepository.save(group);
-    }
-
-    private void validateImageType(MultipartFile file) {
-        String contentType = file.getContentType();
-
-        if (!VALID_IMAGE_FORMAT.contains(contentType)) {
-            throw new FailedImageUploadException(
-                    ErrorCode.INVALID_IMAGE_FORMAT,
-                    "",
-                    file.getOriginalFilename()
-            );
-        }
     }
 }

--- a/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
@@ -84,12 +84,12 @@ public class DiaryQueryService {
                 groupId,
                 today.getYear(),
                 today.getMonthValue(),
-                today.getDayOfMonth());
+                today.getDayOfMonth()
+        );
         return todayDiary;
     }
 
-    private Long getTodayDiaryId(Boolean isMyOrder, Long memberId, Diary todayDiary
-    ) {
+    private Long getTodayDiaryId(Boolean isMyOrder, Long memberId, Diary todayDiary) {
         if (todayDiary.getMember().getId().equals(memberId)) {
             return todayDiary.getId();
         }

--- a/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
@@ -7,7 +7,6 @@ import com.exchangediary.diary.ui.dto.response.DiaryIdResponse;
 import com.exchangediary.diary.ui.dto.response.DiaryMonthlyResponse;
 import com.exchangediary.diary.ui.dto.response.DiaryResponse;
 import com.exchangediary.global.exception.ErrorCode;
-import com.exchangediary.global.exception.serviceexception.InvalidDateException;
 import com.exchangediary.global.exception.serviceexception.NotFoundException;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.service.GroupQueryService;
@@ -17,9 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,9 +24,10 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DiaryQueryService {
-    private final DiaryRepository diaryRepository;
     private final GroupQueryService groupQueryService;
     private final MemberQueryService memberQueryService;
+    private final DiaryValidationService diaryValidationService;
+    private final DiaryRepository diaryRepository;
 
     public DiaryResponse viewDiary(Long diaryId) {
         Diary diary = diaryRepository.findById(diaryId)
@@ -42,14 +40,14 @@ public class DiaryQueryService {
     }
 
     public DiaryMonthlyResponse viewMonthlyDiary(int year, int month, Long groupId) {
-        checkValidDate(year, month, null);
+        diaryValidationService.validateYearMonthFormat(year, month);
         groupQueryService.findGroup(groupId); //Todo: 그룹 인가 구현 후 삭제 될 코드
         List<Diary> diaries = diaryRepository.findAllByGroupYearAndMonth(groupId, year, month);
         return DiaryMonthlyResponse.of(year, month, diaries);
     }
 
     public DiaryIdResponse findDiaryIdByDate(int year, int month, int day, Long groupId) {
-        checkValidDate(year, month, day);
+        diaryValidationService.validateDateFormat(year, month, day);
         Long diaryId = diaryRepository.findIdByGroupAndDate(groupId, year, month, day)
                 .orElseThrow(() -> new NotFoundException(
                         ErrorCode.DIARY_NOT_FOUND,
@@ -62,7 +60,7 @@ public class DiaryQueryService {
     }
 
     public DiaryWritableStatusResponse getDiaryWritableStatus(Long groupId, Long memberId) {
-        Boolean writtenTodayDiary = false;
+        boolean writtenTodayDiary = false;
         Long diaryId = null;
 
         Boolean isMyOrder = isCurrentOrder(groupId, memberId);
@@ -72,26 +70,6 @@ public class DiaryQueryService {
             diaryId = getTodayDiaryId(isMyOrder, memberId, todayDiary.get());
         }
         return DiaryWritableStatusResponse.of(isMyOrder, writtenTodayDiary, diaryId);
-    }
-
-    private void checkValidDate(int year, int month, Integer day) {
-        try {
-            if (day == null) {
-                YearMonth.of(year, month);
-            } else {
-                LocalDate.of(year, month, day);
-            }
-        } catch (DateTimeException exception) {
-            String date = String.format("%d-%02d", year, month);
-            if (day != null) {
-                date += String.format("-%02d", day);
-            }
-            throw new InvalidDateException(
-                    ErrorCode.INVALID_DATE,
-                    "",
-                    date
-            );
-        }
     }
 
     private Boolean isCurrentOrder(Long groupId, Long memberId) {

--- a/src/main/java/com/exchangediary/diary/service/DiaryValidationService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryValidationService.java
@@ -56,10 +56,10 @@ public class DiaryValidationService {
     public void checkTodayDiaryExistent(Long groupId) {
         LocalDate today = LocalDate.now();
         Optional<Long> todayDiary = diaryRepository.findIdByGroupAndDate(
-                        groupId,
-                        today.getYear(),
-                        today.getMonthValue(),
-                        today.getDayOfMonth()
+                groupId,
+                today.getYear(),
+                today.getMonthValue(),
+                today.getDayOfMonth()
         );
 
         if (todayDiary.isPresent()) {

--- a/src/main/java/com/exchangediary/diary/service/DiaryValidationService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryValidationService.java
@@ -1,0 +1,85 @@
+package com.exchangediary.diary.service;
+
+import com.exchangediary.diary.domain.DiaryRepository;
+import com.exchangediary.global.exception.ErrorCode;
+import com.exchangediary.global.exception.serviceexception.DuplicateException;
+import com.exchangediary.global.exception.serviceexception.FailedImageUploadException;
+import com.exchangediary.global.exception.serviceexception.InvalidDateException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryValidationService {
+    private static final Set<String> VALID_IMAGE_FORMAT = Set.of(
+            "image/jpeg",
+            "image/gif",
+            "image/png",
+            "image/heic",
+            "image/heif"
+    );
+    private final DiaryRepository diaryRepository;
+
+    public void validateYearMonthFormat(int year, int month) {
+        try {
+            YearMonth.of(year, month);
+        } catch (DateTimeException exception) {
+            throw new InvalidDateException(
+                    ErrorCode.INVALID_DATE,
+                    "",
+                    String.format("%d-%02d", year, month)
+            );
+        }
+    }
+
+    public void validateDateFormat(int year, int month, int day) {
+        try {
+            LocalDate.of(year, month, day);
+        } catch (DateTimeException exception) {
+            throw new InvalidDateException(
+                    ErrorCode.INVALID_DATE,
+                    "",
+                    String.format("%d-%02d-%02d", year, month, day)
+            );
+        }
+    }
+
+    public void checkTodayDiaryExistent(Long groupId) {
+        LocalDate today = LocalDate.now();
+        Optional<Long> todayDiary = diaryRepository.findIdByGroupAndDate(
+                        groupId,
+                        today.getYear(),
+                        today.getMonthValue(),
+                        today.getDayOfMonth()
+        );
+
+        if (todayDiary.isPresent()) {
+            throw new DuplicateException(
+                    ErrorCode.DIARY_DUPLICATED,
+                    "",
+                    today.toString()
+            );
+        }
+    }
+
+    public void validateImageType(MultipartFile file) {
+        String contentType = file.getContentType();
+
+        if (!VALID_IMAGE_FORMAT.contains(contentType)) {
+            throw new FailedImageUploadException(
+                    ErrorCode.INVALID_IMAGE_FORMAT,
+                    "",
+                    file.getOriginalFilename()
+            );
+        }
+    }
+}

--- a/src/test/java/com/exchangediary/diary/api/DiaryCreateApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryCreateApiTest.java
@@ -2,7 +2,9 @@ package com.exchangediary.diary.api;
 
 import com.exchangediary.ApiBaseTest;
 import com.exchangediary.diary.domain.DiaryRepository;
+import com.exchangediary.diary.domain.UploadImageRepository;
 import com.exchangediary.diary.domain.entity.Diary;
+import com.exchangediary.diary.domain.entity.UploadImage;
 import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
@@ -31,9 +33,11 @@ class DiaryCreateApiTest extends ApiBaseTest {
     private GroupRepository groupRepository;
     @Autowired
     private DiaryRepository diaryRepository;
+    @Autowired
+    private UploadImageRepository uploadImageRepository;
 
     @Test
-    void 일기_작성_성공() throws JsonProcessingException {
+    void 일기_작성_성공_사진포함() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
         member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
@@ -62,10 +66,12 @@ class DiaryCreateApiTest extends ApiBaseTest {
         assertThat(newDiary.getMember().getId()).isEqualTo(member.getId());
         assertThat(newDiary.getContent()).isEqualTo(data.get("content"));
         assertThat(newDiary.getMoodLocation()).isEqualTo(data.get("moodLocation"));
+        UploadImage uploadImage = uploadImageRepository.findAll().getLast();
+        assertThat(uploadImage.getDiary().getId()).isEqualTo(newDiary.getId());
     }
 
     @Test
-    void 일기_작성_성공_내용만() throws JsonProcessingException {
+    void 일기_작성_성공_사진_미포함() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
         member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);

--- a/src/test/java/com/exchangediary/diary/domain/DiaryRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/diary/domain/DiaryRepositoryUnitTest.java
@@ -35,21 +35,20 @@ public class DiaryRepositoryUnitTest {
 
     @Test
     void 일기_사진_영속_확인() {
+        byte[] image = getBinaryImage();
         UploadImage uploadImage = UploadImage.builder()
-                .image(getBinaryImage())
+                .image(image)
                 .build();
         Diary diary = Diary.builder()
                 .content("하이하이")
                 .moodLocation("/images/write-page/emoji/sleepy.svg")
                 .uploadImage(uploadImage)
                 .build();
-        uploadImage.uploadToDiary(diary);
         entityManager.persist(diary);
 
-        Diary result = uploadImageRepository.findById(uploadImage.getId()).get().getDiary();
+        UploadImage updatedUploadImage = uploadImageRepository.findById(uploadImage.getId()).get();
 
-        assertThat(result.getContent()).isEqualTo("하이하이");
-        assertThat(result.getUploadImage().getId()).isEqualTo(uploadImage.getId());
+        assertThat(updatedUploadImage.getImage()).isEqualTo(image);
     }
 
     @Test
@@ -62,7 +61,6 @@ public class DiaryRepositoryUnitTest {
                 .moodLocation("/images/write-page/emoji/sleepy.svg")
                 .uploadImage(uploadImage)
                 .build();
-        uploadImage.uploadToDiary(diary);
         entityManager.persist(diary);
 
         diaryRepository.delete(diary);


### PR DESCRIPTION
## Work Description
> 일기 서비스 리팩터링

- 일기 관련 유효성 검사 메서드들을 하나의 서비스로 분리했습니다. `DiaryValidationService`
- 일기 작성하기 메서드의 코드 중복을 제거했습니다.
  - 사진을 업로드하는 경우와 그렇지 않은 경우를 하나의 흐름으로 작동 가능하게끔 리팩터링했습니다.
- 한 번의 생성으로 가능한 작업들이 setter 메서드에 의해 값이 변경되고 있는 부분들을 수정했습니다.
  - setter의 사용을 지양하고 생성자 호출 시 필드값들이 초기화되도록 해주었습니다.
  - 따라서 UplaodImage와 Diary의 모든 필드(id 제외)에 final 타입을 추가했습니다. 

## ISSUE
- closed #284


## Screenshot
#### 수정된 테스트 결과
<img width="442" alt="Screenshot 2024-10-23 at 3 00 44 AM" src="https://github.com/user-attachments/assets/0eb5248f-fd04-45b4-af75-971b24a377b3">
<img width="452" alt="Screenshot 2024-10-23 at 2 57 58 AM" src="https://github.com/user-attachments/assets/79a7467f-422a-407b-b91a-27aa7861d695">

