### PR TITLE
테스트에서 발생하는 not null 제약조건 오류 해결

### DIFF
--- a/src/main/java/com/exchangediary/group/domain/entity/Group.java
+++ b/src/main/java/com/exchangediary/group/domain/entity/Group.java
@@ -43,12 +43,12 @@ public class Group extends BaseEntity {
     @OrderBy("order_in_group ASC")
     private List<Member> members;
 
-    public static Group of(String groupName, String code, LocalDate lastSkipOrderDate) {
+    public static Group of(String groupName, String code) {
         return Group.builder()
                 .name(groupName)
                 .currentOrder(1)
                 .code(code)
-                .lastSkipOrderDate(lastSkipOrderDate)
+                .lastSkipOrderDate(LocalDate.now().minusDays(1))
                 .build();
     }
 

--- a/src/main/java/com/exchangediary/group/service/GroupCreateService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupCreateService.java
@@ -30,7 +30,7 @@ public class GroupCreateService {
     }
 
     private Group saveGroup(String groupName) {
-        Group group = Group.of(groupName, groupCodeService.generateCode(groupName), LocalDate.now().minusDays(1));
+        Group group = Group.of(groupName, groupCodeService.generateCode(groupName));
         return groupRepository.save(group);
     }
 

--- a/src/test/java/com/exchangediary/diary/api/DiaryCreateApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryCreateApiTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import java.io.File;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -268,6 +269,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
                 .name("버니즈")
                 .currentOrder(currentOrder)
                 .code("code")
+                .lastSkipOrderDate(LocalDate.now())
                 .build();
     }
 

--- a/src/test/java/com/exchangediary/diary/api/DiaryFindIdApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryFindIdApiTest.java
@@ -110,11 +110,7 @@ class DiaryFindIdApiTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name("버니즈")
-                .currentOrder(0)
-                .code("code")
-                .build();
+        return Group.of("버니즈", "code");
     }
 
     private Diary createDiary(Group group) {

--- a/src/test/java/com/exchangediary/diary/api/DiaryViewMonthlyTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryViewMonthlyTest.java
@@ -69,11 +69,7 @@ class DiaryViewMonthlyTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name("버니즈")
-                .currentOrder(0)
-                .code("code")
-                .build();
+        return Group.of("버니즈", "code");
     }
 
     private Diary createDiary(Group group) {

--- a/src/test/java/com/exchangediary/diary/api/DiaryWritableStatusApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryWritableStatusApiTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -156,6 +157,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
                 .name("버니즈")
                 .currentOrder(currentOrder)
                 .code("code")
+                .lastSkipOrderDate(LocalDate.now())
                 .build();
     }
 

--- a/src/test/java/com/exchangediary/diary/service/DiaryQueryServiceTest.java
+++ b/src/test/java/com/exchangediary/diary/service/DiaryQueryServiceTest.java
@@ -57,11 +57,7 @@ public class DiaryQueryServiceTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name(GROUP_NAME)
-                .currentOrder(0)
-                .code("code")
-                .build();
+        return Group.of("버니즈", "code");
     }
 
     private Diary createDiary(Member member, Group group) {

--- a/src/test/java/com/exchangediary/group/api/GroupCodeApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupCodeApiTest.java
@@ -68,10 +68,6 @@ public class GroupCodeApiTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name(GROUP_NAME)
-                .currentOrder(0)
-                .code("code")
-                .build();
+        return Group.of(GROUP_NAME, "code");
     }
 }

--- a/src/test/java/com/exchangediary/group/api/GroupJoinApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupJoinApiTest.java
@@ -69,11 +69,7 @@ class GroupJoinApiTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name(GROUP_NAME)
-                .currentOrder(0)
-                .code("code")
-                .build();
+        return Group.of(GROUP_NAME, "code");
     }
 
     private Member createMemberInGroup(Group group) {

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
@@ -60,7 +60,7 @@ public class GroupLeaderHandOverApiTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return groupRepository.save(Group.of("group-name", "code", LocalDate.now().minusDays(1)));
+        return groupRepository.save(Group.of("group-name", "code"));
     }
 
     private void updateSelf(Group group, int order, GroupRole role) {

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
@@ -64,7 +64,7 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
     }
 
     private Group createGroup(int order) {
-        Group group = Group.of("group-name", "code", LocalDate.now().minusDays(1));
+        Group group = Group.of("group-name", "code");
         group.updateCurrentOrder(order, 2);
         return groupRepository.save(group);
     }

--- a/src/test/java/com/exchangediary/group/api/GroupMembersOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupMembersOrderApiTest.java
@@ -125,11 +125,7 @@ public class GroupMembersOrderApiTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name("groupname")
-                .currentOrder(1)
-                .code("code")
-                .build();
+        return Group.of("GROUP_NAME", "code");
     }
 
     private Member createMember(Group group, int index, String profileImage) {

--- a/src/test/java/com/exchangediary/group/api/GroupNicknameApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupNicknameApiTest.java
@@ -49,11 +49,7 @@ class GroupNicknameApiTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name(GROUP_NAME)
-                .currentOrder(0)
-                .code("code")
-                .build();
+        return Group.of(GROUP_NAME, "code");
     }
 
     private Member createMember(Group group) {

--- a/src/test/java/com/exchangediary/group/api/GroupProfileApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupProfileApiTest.java
@@ -104,10 +104,6 @@ class GroupProfileApiTest extends ApiBaseTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name(GROUP_NAME)
-                .currentOrder(0)
-                .code("code")
-                .build();
+        return Group.of(GROUP_NAME, "code");
     }
 }

--- a/src/test/java/com/exchangediary/group/service/GroupCodeServiceTest.java
+++ b/src/test/java/com/exchangediary/group/service/GroupCodeServiceTest.java
@@ -71,10 +71,6 @@ public class GroupCodeServiceTest {
     }
 
     private Group createGroup() {
-        return Group.builder()
-                .name(GROUP_NAME)
-                .currentOrder(0)
-                .code("code")
-                .build();
+        return Group.of(GROUP_NAME, "code");
     }
 }

--- a/src/test/java/com/exchangediary/member/domain/MemberRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/member/domain/MemberRepositoryUnitTest.java
@@ -23,11 +23,7 @@ public class MemberRepositoryUnitTest {
 
     @Test
     void 일기_작성_순서_조회() {
-        Group group = Group.builder()
-                .name("버니즈")
-                .currentOrder(0)
-                .code("code")
-                .build();
+        Group group = Group.of("버니즈", "code");
         entityManager.persist(group);
         List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7);
         Collections.shuffle(nums);


### PR DESCRIPTION
## Work Description
> 테스트에서 발생하는 not null 제약조건 오류 해결

- Group의 not null 제약조건이 걸린 lastSkipOrderDate 필드 값을 설정하지 않아서 오류가 발생했습니다.
- 따라서 그룹 생성 시 사용되는 정적팩터리메서드 of() 메서드에서 lastSkipOrderDate을 그룹 생성 전날로 설정해주었습니다.
- 또한 모든 테스트에서 그룹 생성 시 lastSkipOrderDate 값을 설정해주었습니다.

## ISSUE
- closed #287


## Screenshot
#### 변경 후 테스트 결과
<img width="1136" alt="Screenshot 2024-10-24 at 1 27 45 AM" src="https://github.com/user-attachments/assets/f282c597-681c-49ca-aca7-24991a18f72b">


