### PR TITLE
일기 작성 인가 인터셉터 구현

### DIFF
--- a/src/main/java/com/exchangediary/diary/service/DiaryAuthorizationService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryAuthorizationService.java
@@ -15,7 +15,7 @@ public class DiaryAuthorizationService {
     private final DiaryQueryService diaryQueryService;
 
     public boolean canWriteDiary(Long memberId, Long groupId) {
-        if (groupQueryService.isSameWithGroupCurrentOrder(memberId)) {
+        if (!groupQueryService.isSameWithGroupCurrentOrder(memberId)) {
             throw new ForbiddenException(ErrorCode.DIARY_WRITE_FORBIDDEN, "", "");
         }
         if (diaryQueryService.findTodayDiary(groupId).isPresent()) {

--- a/src/main/java/com/exchangediary/diary/service/DiaryAuthorizationService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryAuthorizationService.java
@@ -1,0 +1,26 @@
+package com.exchangediary.diary.service;
+
+import com.exchangediary.global.exception.ErrorCode;
+import com.exchangediary.global.exception.serviceexception.ForbiddenException;
+import com.exchangediary.group.service.GroupQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryAuthorizationService {
+    private final GroupQueryService groupQueryService;
+    private final DiaryQueryService diaryQueryService;
+
+    public boolean canWriteDiary(Long memberId, Long groupId) {
+        if (groupQueryService.isSameWithGroupCurrentOrder(memberId)) {
+            throw new ForbiddenException(ErrorCode.DIARY_WRITE_FORBIDDEN, "", "");
+        }
+        if (diaryQueryService.findTodayDiary(groupId).isPresent()) {
+            throw new ForbiddenException(ErrorCode.DIARY_WRITE_FORBIDDEN, "", "");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryQueryService.java
@@ -78,7 +78,7 @@ public class DiaryQueryService {
         return group.getCurrentOrder().equals(member.getOrderInGroup());
     }
 
-    private Optional<Diary> findTodayDiary(Long groupId) {
+    public Optional<Diary> findTodayDiary(Long groupId) {
         LocalDate today = LocalDate.now();
         Optional<Diary> todayDiary = diaryRepository.findByGroupAndDate(
                 groupId,

--- a/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
@@ -35,7 +35,6 @@ public class DiaryWriteService {
         Group group = groupQueryService.findGroup(groupId);
         diaryValidationService.checkTodayDiaryExistent(groupId);
 
-
         try {
             Diary diary = Diary.from(diaryRequest, member, group);
             uploadImage(file, diary);

--- a/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
@@ -7,7 +7,6 @@ import com.exchangediary.diary.domain.entity.UploadImage;
 import com.exchangediary.diary.ui.dto.request.DiaryRequest;
 import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.global.exception.serviceexception.FailedImageUploadException;
-import com.exchangediary.global.exception.serviceexception.ForbiddenException;
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.service.GroupQueryService;
@@ -23,7 +22,7 @@ import java.io.IOException;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class DiaryCommandService {
+public class DiaryWriteService {
     private final MemberQueryService memberQueryService;
     private final GroupQueryService groupQueryService;
     private final DiaryValidationService diaryValidationService;
@@ -31,18 +30,11 @@ public class DiaryCommandService {
     private final GroupRepository groupRepository;
     private final UploadImageRepository uploadImageRepository;
 
-    public Long createDiary(DiaryRequest diaryRequest, MultipartFile file, Long groupId, Long memberId) {
+    public Long writeDiary(DiaryRequest diaryRequest, MultipartFile file, Long groupId, Long memberId) {
         Member member = memberQueryService.findMember(memberId);
         Group group = groupQueryService.findGroup(groupId);
         diaryValidationService.checkTodayDiaryExistent(groupId);
-        //Todo: 일기 작성 인가 후 삭제
-        if (!member.getOrderInGroup().equals(group.getCurrentOrder())) {
-            throw new ForbiddenException(
-                    ErrorCode.DIARY_WRITE_FORBIDDEN,
-                    "",
-                    String.valueOf(group.getCurrentOrder())
-            );
-        }
+
 
         try {
             Diary diary = Diary.from(diaryRequest, member, group);

--- a/src/main/java/com/exchangediary/diary/ui/ApiDiaryController.java
+++ b/src/main/java/com/exchangediary/diary/ui/ApiDiaryController.java
@@ -1,6 +1,6 @@
 package com.exchangediary.diary.ui;
 
-import com.exchangediary.diary.service.DiaryCommandService;
+import com.exchangediary.diary.service.DiaryWriteService;
 import com.exchangediary.diary.service.DiaryQueryService;
 import com.exchangediary.diary.ui.dto.request.DiaryRequest;
 import com.exchangediary.diary.ui.dto.response.DiaryWritableStatusResponse;
@@ -24,17 +24,17 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/api/groups/{groupId}/diaries")
 public class ApiDiaryController {
-    private final DiaryCommandService diaryCommandService;
+    private final DiaryWriteService diaryWriteService;
     private final DiaryQueryService diaryQueryService;
 
     @PostMapping
-    public ResponseEntity<Void> createDiary(
+    public ResponseEntity<Void> writeDiary(
             @RequestPart(name = "data") @Valid DiaryRequest diaryRequest,
             @RequestPart(name = "file", required = false) MultipartFile file,
             @PathVariable Long groupId,
             @RequestAttribute Long memberId
     ) {
-        Long diaryId = diaryCommandService.createDiary(diaryRequest, file, groupId, memberId);
+        Long diaryId = diaryWriteService.writeDiary(diaryRequest, file, groupId, memberId);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .header("Content-Location", "/group/" + groupId + "/diary/" + diaryId)

--- a/src/main/java/com/exchangediary/global/config/web/WebConfig.java
+++ b/src/main/java/com/exchangediary/global/config/web/WebConfig.java
@@ -29,7 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns("/group", "/diary/**", "/group/**", "/api/**")
                 .excludePathPatterns("/api/kakao/callback");
         registry.addInterceptor(new BelongToGroupInterceptor(memberQueryService))
-                .addPathPatterns("/group/*");
+                .addPathPatterns("/group", "/group/*");
         registry.addInterceptor(new LoginInterceptor(jwtService, cookieService))
                 .addPathPatterns("/login");
 

--- a/src/main/java/com/exchangediary/global/config/web/WebConfig.java
+++ b/src/main/java/com/exchangediary/global/config/web/WebConfig.java
@@ -1,8 +1,10 @@
 package com.exchangediary.global.config.web;
 
+import com.exchangediary.diary.service.DiaryAuthorizationService;
 import com.exchangediary.global.config.web.interceptor.BelongToGroupInterceptor;
 import com.exchangediary.global.config.web.interceptor.JwtAuthenticationInterceptor;
 import com.exchangediary.global.config.web.interceptor.LoginInterceptor;
+import com.exchangediary.global.config.web.interceptor.WriteDiaryAuthorizationInterceptor;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.service.CookieService;
 import com.exchangediary.member.service.JwtService;
@@ -19,6 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final CookieService cookieService;
     private final MemberQueryService memberQueryService;
     private final MemberRepository memberRepository;
+    private final DiaryAuthorizationService diaryAuthorizationService;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -26,8 +29,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns("/group", "/diary/**", "/group/**", "/api/**")
                 .excludePathPatterns("/api/kakao/callback");
         registry.addInterceptor(new BelongToGroupInterceptor(memberQueryService))
-                .addPathPatterns("/group/{*groupId}");
+                .addPathPatterns("/group/*");
         registry.addInterceptor(new LoginInterceptor(jwtService, cookieService))
                 .addPathPatterns("/login");
+
+        registry.addInterceptor(new WriteDiaryAuthorizationInterceptor(diaryAuthorizationService))
+                .addPathPatterns("/group/*/diary", "/api/groups/*/diaries");
     }
 }

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/WriteDiaryAuthorizationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/WriteDiaryAuthorizationInterceptor.java
@@ -21,6 +21,10 @@ public class WriteDiaryAuthorizationInterceptor implements HandlerInterceptor {
             HttpServletResponse response,
             Object handler
     ) throws IOException {
+        if (!request.getParameterMap().isEmpty()) {
+            return true;
+        }
+
         Long memberId = (Long) request.getAttribute("memberId");
 //        Long groupId = (Long) request.getAttribute("groupId"); todo: 그룹 인가 구현 후 주석 제거 & 아래 코드 제거
         Map<?, ?> pathVariables = (Map<?, ?>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/WriteDiaryAuthorizationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/WriteDiaryAuthorizationInterceptor.java
@@ -1,0 +1,40 @@
+package com.exchangediary.global.config.web.interceptor;
+
+import com.exchangediary.diary.service.DiaryAuthorizationService;
+import com.exchangediary.global.exception.serviceexception.ForbiddenException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class WriteDiaryAuthorizationInterceptor implements HandlerInterceptor {
+    private final DiaryAuthorizationService diaryAuthorizationService;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) throws IOException {
+        Long memberId = (Long) request.getAttribute("memberId");
+//        Long groupId = (Long) request.getAttribute("groupId"); todo: 그룹 인가 구현 후 주석 제거 & 아래 코드 제거
+        Map<?, ?> pathVariables = (Map<?, ?>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        Long groupId = Long.valueOf(String.valueOf(pathVariables.get("groupId")));
+
+        try {
+            diaryAuthorizationService.canWriteDiary(memberId, groupId);
+        } catch (ForbiddenException exception) {
+            if (request.getRequestURI().contains("/api")) {
+                throw exception;
+            }
+            response.sendRedirect("/group/" + groupId);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/exchangediary/group/domain/GroupRepository.java
+++ b/src/main/java/com/exchangediary/group/domain/GroupRepository.java
@@ -2,9 +2,12 @@ package com.exchangediary.group.domain;
 
 import com.exchangediary.group.domain.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findByCode(String code);
+    @Query("SELECT g.id FROM Group g JOIN g.members m WHERE m.id = :memberId")
+    Optional<Long> findGroupIdCurrentOrderEqualsMemberOrder(Long memberId);
 }

--- a/src/main/java/com/exchangediary/group/domain/GroupRepository.java
+++ b/src/main/java/com/exchangediary/group/domain/GroupRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findByCode(String code);
-    @Query("SELECT g.id FROM Group g JOIN g.members m WHERE m.id = :memberId")
+    @Query("SELECT g.id FROM Group g JOIN g.members m ON m.id = :memberId WHERE m.orderInGroup = g.currentOrder")
     Optional<Long> findGroupIdCurrentOrderEqualsMemberOrder(Long memberId);
 }

--- a/src/main/java/com/exchangediary/group/service/GroupQueryService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupQueryService.java
@@ -64,4 +64,8 @@ public class GroupQueryService {
                         String.valueOf(memberId)
                 ));
     }
+
+    public boolean isSameWithGroupCurrentOrder(Long memberId) {
+        return groupRepository.findGroupIdCurrentOrderEqualsMemberOrder(memberId).isPresent();
+    }
 }

--- a/src/test/java/com/exchangediary/global/config/interceptor/WriteDiaryAuthorizationInterceptorTest.java
+++ b/src/test/java/com/exchangediary/global/config/interceptor/WriteDiaryAuthorizationInterceptorTest.java
@@ -1,0 +1,143 @@
+package com.exchangediary.global.config.interceptor;
+
+import com.exchangediary.ApiBaseTest;
+import com.exchangediary.diary.domain.DiaryRepository;
+import com.exchangediary.diary.domain.entity.Diary;
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.domain.entity.Group;
+import com.exchangediary.member.domain.enums.GroupRole;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+
+
+public class WriteDiaryAuthorizationInterceptorTest extends ApiBaseTest {
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private DiaryRepository diaryRepository;
+
+    @Test
+    void 일기_작성_권한_허가_성공() {
+        Group group = createGroup();
+        updateSelf(group, 1);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().get(String.format("/group/%d/diary", group.getId()))
+                .then()
+                .log().status()
+                .log().headers()
+                .statusCode(HttpStatus.OK.value());
+    }
+    
+    @Test
+    void 일기_작성_권한_허가_실패_내_순서아님() {
+        Group group = createGroup();
+        updateSelf(group, 2);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .redirects().follow(false)
+                .when().get(String.format("/group/%d/diary", group.getId()))
+                .then()
+                .log().status()
+                .log().headers()
+                .statusCode(HttpStatus.FOUND.value());
+    }
+
+    @Test
+    void 일기_작성_권한_허가_실패_오늘_일기_작성됨() {
+        Group group = createGroup();
+        updateSelf(group, 1);
+        createDiary(group);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .redirects().follow(false)
+                .when().get(String.format("/group/%d/diary", group.getId()))
+                .then()
+                .log().status()
+                .log().headers()
+                .statusCode(HttpStatus.FOUND.value());
+    }
+
+    @Test
+    void 일기_작성_API_권한_허가_실패_내_순서아님() {
+        Group group = createGroup();
+        updateSelf(group, 2);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().get(String.format("/api/groups/%d/diaries", group.getId()))
+                .then()
+                .log().status()
+                .log().headers()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    void 일기_작성_API_권한_허가_실패_오늘_일기_작성됨() {
+        Group group = createGroup();
+        updateSelf(group, 1);
+        createDiary(group);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().get(String.format("/api/groups/%d/diaries", group.getId()))
+                .then()
+                .log().status()
+                .log().headers()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    void 일기_id_조회_요청_정상_작동_확인() {
+        Group group = createGroup();
+        updateSelf(group, 2);
+        createDiary(group);
+        LocalDate today = LocalDate.now();
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().get(String.format("/group/%d/diary?year=%d&month=%d&day=%d", group.getId(), today.getYear(), today.getMonthValue(), today.getDayOfMonth()))
+                .then()
+                .log().status()
+                .log().headers()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    private Group createGroup() {
+        return groupRepository.save(Group.of("group-name", "code"));
+    }
+
+    private void updateSelf(Group group, int order) {
+        this.member.updateMemberGroupInfo(
+                "me",
+                "red",
+                order,
+                GroupRole.GROUP_MEMBER,
+                group
+        );
+        memberRepository.save(this.member);
+    }
+
+    private void createDiary(Group group) {
+        Diary diary = Diary.builder()
+                .content("내용")
+                .moodLocation("happy")
+                .member(this.member)
+                .group(group)
+                .build();
+        diaryRepository.save(diary);
+    }
+}

--- a/src/test/java/com/exchangediary/group/domain/GroupRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/group/domain/GroupRepositoryUnitTest.java
@@ -1,0 +1,49 @@
+package com.exchangediary.group.domain;
+
+import com.exchangediary.group.domain.entity.Group;
+import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class GroupRepositoryUnitTest {
+    @PersistenceContext
+    private EntityManager entityManager;
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Test
+    void 내_그룹순서가_현재_그룹순서와_일치하는지_확인() {
+        Group group = Group.of("버니즈", "code");
+        Member member = Member.from(1L);
+        member.updateMemberGroupInfo("nickname", "red", 1, GroupRole.GROUP_MEMBER, group);
+        entityManager.persist(group);
+        entityManager.persist(member);
+
+        Optional<Long> groupId = groupRepository.findGroupIdCurrentOrderEqualsMemberOrder(member.getId());
+
+        assertThat(groupId.isPresent()).isTrue();
+        assertThat(groupId.get()).isEqualTo(group.getId());
+    }
+
+    @Test
+    void 내_그룹순서가_현재_그룹순서와_일치_안함() {
+        Group group = Group.of("버니즈", "code");
+        Member member = Member.from(1L);
+        member.updateMemberGroupInfo("nickname", "red", 2, GroupRole.GROUP_MEMBER, group);
+        entityManager.persist(group);
+        entityManager.persist(member);
+
+        Optional<Long> groupId = groupRepository.findGroupIdCurrentOrderEqualsMemberOrder(member.getId());
+
+        assertThat(groupId.isPresent()).isFalse();
+    }
+}


### PR DESCRIPTION
## Work Description
일기 작성 인가 인터셉터 구현

<br>

- 일기 작성 인가 인터셉터를 구현했습니다.
> 일기 작성은 언제 허가되는가?
> 1. 사용자 그룹 순서가 그룹 순서와 일치
>  2. 오늘 작성된 일기가 없음.
- `DiaryAuthorizationService`을 만들어서 위 두 조건을 확인해주었습니다.
- 일기 인가가 필요한 url(`/group/{groupId}/diary`, `/api/groups/{groupId}/diaries`) 요청 시 
위 인터셉터를 거치도록 config에 추가했습니다.
- 일기 인가 인터셉터 테스트를 작성했습니다.

## ISSUE
- closed #253

## Screenshot
<img width="453" alt="Screenshot 2024-10-24 at 2 47 34 AM" src="https://github.com/user-attachments/assets/dc1c8567-7db4-498b-978c-cf0f97fbfc51">

