### PR TITLE
일기 조회 인가 구현

### DIFF
--- a/src/main/java/com/exchangediary/diary/domain/DiaryRepository.java
+++ b/src/main/java/com/exchangediary/diary/domain/DiaryRepository.java
@@ -14,4 +14,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Optional<Long> findIdByGroupAndDate(Long groupId, int year, int month, int day);
     @Query("SELECT d FROM Diary d WHERE d.group.id = :groupId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month AND DAY(d.createdAt) = :day")
     Optional<Diary> findByGroupAndDate(Long groupId, int year, int month, int day);
+    @Query("SELECT CASE WHEN m.lastViewableDiaryDate >= CAST(d.createdAt AS DATE) THEN true ELSE false END " +
+            "FROM Member m JOIN Diary d " +
+            "ON m.id = :memberId AND d.id = :diaryId")
+    Boolean isViewableDiary(Long memberId,  Long diaryId);
 }

--- a/src/main/java/com/exchangediary/diary/service/DiaryAuthorizationService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryAuthorizationService.java
@@ -1,5 +1,6 @@
 package com.exchangediary.diary.service;
 
+import com.exchangediary.diary.domain.DiaryRepository;
 import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.global.exception.serviceexception.ForbiddenException;
 import com.exchangediary.group.service.GroupQueryService;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DiaryAuthorizationService {
     private final GroupQueryService groupQueryService;
     private final DiaryQueryService diaryQueryService;
+    private final DiaryRepository diaryRepository;
 
     public boolean canWriteDiary(Long memberId, Long groupId) {
         if (!groupQueryService.isSameWithGroupCurrentOrder(memberId)) {
@@ -20,6 +22,13 @@ public class DiaryAuthorizationService {
         }
         if (diaryQueryService.findTodayDiary(groupId).isPresent()) {
             throw new ForbiddenException(ErrorCode.DIARY_WRITE_FORBIDDEN, "", "");
+        }
+        return true;
+    }
+
+    public boolean canViewDiary(Long memberId, Long diaryId) {
+        if (!diaryRepository.isViewableDiary(memberId, diaryId)) {
+            throw new ForbiddenException(ErrorCode.DIARY_VIEW_FORBIDDEN, "", "");
         }
         return true;
     }

--- a/src/main/java/com/exchangediary/global/config/web/WebConfig.java
+++ b/src/main/java/com/exchangediary/global/config/web/WebConfig.java
@@ -4,6 +4,7 @@ import com.exchangediary.diary.service.DiaryAuthorizationService;
 import com.exchangediary.global.config.web.interceptor.BelongToGroupInterceptor;
 import com.exchangediary.global.config.web.interceptor.JwtAuthenticationInterceptor;
 import com.exchangediary.global.config.web.interceptor.LoginInterceptor;
+import com.exchangediary.global.config.web.interceptor.ViewDiaryAuthorizationInterceptor;
 import com.exchangediary.global.config.web.interceptor.WriteDiaryAuthorizationInterceptor;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.service.CookieService;
@@ -35,5 +36,8 @@ public class WebConfig implements WebMvcConfigurer {
 
         registry.addInterceptor(new WriteDiaryAuthorizationInterceptor(diaryAuthorizationService))
                 .addPathPatterns("/group/*/diary", "/api/groups/*/diaries");
+        registry.addInterceptor(new ViewDiaryAuthorizationInterceptor(diaryAuthorizationService))
+                .addPathPatterns("/group/*/diary/*", "/api/groups/*/diaries/*")
+                .excludePathPatterns("/api/groups/*/diaries/*/**");
     }
 }

--- a/src/main/java/com/exchangediary/global/config/web/WebConfig.java
+++ b/src/main/java/com/exchangediary/global/config/web/WebConfig.java
@@ -37,7 +37,6 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new WriteDiaryAuthorizationInterceptor(diaryAuthorizationService))
                 .addPathPatterns("/group/*/diary", "/api/groups/*/diaries");
         registry.addInterceptor(new ViewDiaryAuthorizationInterceptor(diaryAuthorizationService))
-                .addPathPatterns("/group/*/diary/*", "/api/groups/*/diaries/*")
-                .excludePathPatterns("/api/groups/*/diaries/*/**");
+                .addPathPatterns("/group/*/diary/*");
     }
 }

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/ViewDiaryAuthorizationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/ViewDiaryAuthorizationInterceptor.java
@@ -1,0 +1,39 @@
+package com.exchangediary.global.config.web.interceptor;
+
+import com.exchangediary.diary.service.DiaryAuthorizationService;
+import com.exchangediary.global.exception.serviceexception.ForbiddenException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class ViewDiaryAuthorizationInterceptor implements HandlerInterceptor {
+    private final DiaryAuthorizationService diaryAuthorizationService;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) throws IOException {
+        Long memberId = (Long) request.getAttribute("memberId");
+        Map<?, ?> pathVariables = (Map<?, ?>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        Long diaryId = Long.valueOf(String.valueOf(pathVariables.get("diaryId")));
+
+        try {
+            return diaryAuthorizationService.canViewDiary(memberId, diaryId);
+        } catch (ForbiddenException exception) {
+            if (request.getRequestURI().contains("/api")) {
+                throw exception;
+            }
+            long groupId = Long.parseLong(String.valueOf(pathVariables.get("groupId")));
+            response.sendRedirect("/group/" + groupId);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/exchangediary/global/exception/ErrorCode.java
+++ b/src/main/java/com/exchangediary/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     JWT_TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "jwt 토큰 인증에 실패했습니다."),
 
     DIARY_WRITE_FORBIDDEN(HttpStatus.FORBIDDEN, "일기 작성 권한이 없습니다."),
+    DIARY_VIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "일기 조회 권한이 없습니다."),
 
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "일기를 찾을 수 없습니다."),
     UPLOAD_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "일기 업로드 이미지를 찾을 수 없습니다."),

--- a/src/main/java/com/exchangediary/group/service/GroupCreateService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupCreateService.java
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -36,7 +34,7 @@ public class GroupCreateService {
 
     private void updateMember(Long memberId, GroupCreateRequest request, Group group) {
         Member member = memberQueryService.findMember(memberId);
-        member.updateMemberGroupInfo(request.nickname(), request.profileImage(), 1, GroupRole.GROUP_LEADER, group);
+        member.joinGroup(request.nickname(), request.profileImage(), 1, GroupRole.GROUP_LEADER, group);
         memberRepository.save(member);
     }
 }

--- a/src/main/java/com/exchangediary/group/service/GroupJoinService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupJoinService.java
@@ -29,7 +29,7 @@ public class GroupJoinService {
         groupValidationService.checkProfileDuplicate(members, request.profileImage());
         groupValidationService.checkNumberOfMembers(members.size());
 
-        member.updateMemberGroupInfo(
+        member.joinGroup(
                 request.nickname(),
                 request.profileImage(),
                 members.size() + 1,

--- a/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -22,6 +22,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -40,6 +42,7 @@ public class Member extends BaseEntity {
     private String nickname;
     private String profileImage;
     private Integer orderInGroup;
+    private LocalDate lastViewableDiaryDate;
     @Enumerated(EnumType.STRING)
     private GroupRole groupRole;
     @ManyToOne(fetch = FetchType.LAZY)
@@ -55,7 +58,7 @@ public class Member extends BaseEntity {
                 .build();
     }
 
-    public void updateMemberGroupInfo(
+    public void joinGroup(
             String nickname,
             String profileImage,
             int orderInGroup,
@@ -65,6 +68,7 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.orderInGroup = orderInGroup;
+        this.lastViewableDiaryDate = LocalDate.now();
         this.groupRole = groupRole;
         this.group = group;
     }
@@ -73,7 +77,11 @@ public class Member extends BaseEntity {
         this.groupRole = groupRole;
     }
 
-    public void updateRefreshToken(RefreshToken refreshToken) {
+    public void updateLastViewableDiaryDate(LocalDate lastViewableDiaryDate) {
+        this.lastViewableDiaryDate = lastViewableDiaryDate;
+    }
+
+    public void issueRefreshToken(RefreshToken refreshToken) {
         this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/exchangediary/member/service/MemberRegistrationService.java
+++ b/src/main/java/com/exchangediary/member/service/MemberRegistrationService.java
@@ -19,7 +19,7 @@ public class MemberRegistrationService {
         Member member = memberRepository.findBykakaoId(kakaoId)
                 .orElseGet(() -> signUp(kakaoId));
         RefreshToken refreshToken = issueRefreshToken(member);
-        member.updateRefreshToken(refreshToken);
+        member.issueRefreshToken(refreshToken);
         return MemberIdResponse.from(member.getId());
     }
 

--- a/src/test/java/com/exchangediary/diary/api/DiaryCreateApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryCreateApiTest.java
@@ -41,7 +41,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_사진포함() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         Map<String, String> data = makeDiaryData();
         ObjectMapper objectMapper = new ObjectMapper();
@@ -75,7 +75,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_사진_미포함() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         Map<String, String> data = makeDiaryData();
         ObjectMapper objectMapper = new ObjectMapper();
@@ -129,7 +129,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_순서_확인() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         Member groupMember2 = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));
@@ -166,7 +166,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_순서_확인_맨_첫_순서로() throws JsonProcessingException {
         Group group = createGroup(3);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 3, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 3, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         Member groupMember2 = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));
@@ -203,7 +203,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_성공_순서_확인_내용만() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         Member groupMember2 = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));
@@ -238,7 +238,7 @@ class DiaryCreateApiTest extends ApiBaseTest {
     void 일기_작성_실패_이미지_형식_실패() throws JsonProcessingException {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         Map<String, String> data = makeDiaryData();
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/com/exchangediary/diary/api/DiaryWritableStatusApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryWritableStatusApiTest.java
@@ -32,7 +32,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 내_순서_오늘_일기_작성_완료() {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember));
         Diary diary = createDiary(group, groupMember);
@@ -57,7 +57,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 나의_오늘_일기_작성_완료_순서넘어감() {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 2, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 2, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         Diary diary = createDiary(group, member);
         diaryRepository.save(diary);
@@ -80,7 +80,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 내_순서_오늘_일기_작성_미완료() {
         Group group = createGroup(1);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
 
         DiaryWritableStatusResponse response = RestAssured
@@ -101,7 +101,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 친구_순서_오늘_일기_작성_완료() {
         Group group = createGroup(2);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember));
         Diary diary = createDiary(group, groupMember);
@@ -125,7 +125,7 @@ public class DiaryWritableStatusApiTest extends ApiBaseTest {
     void 친구_순서_오늘_일기_작성_미완료() {
         Group group = createGroup(2);
         groupRepository.save(group);
-        member.updateMemberGroupInfo("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
         Member groupMember = createMemberInGroup(group);
         memberRepository.saveAll(Arrays.asList(member, groupMember));
 

--- a/src/test/java/com/exchangediary/diary/api/DiaryWriteApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryWriteApiTest.java
@@ -21,14 +21,13 @@ import org.springframework.http.MediaType;
 
 import java.io.File;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-class DiaryCreateApiTest extends ApiBaseTest {
+class DiaryWriteApiTest extends ApiBaseTest {
     private static final String API_PATH = "/api/groups/%d/diaries";
     @Autowired
     private GroupRepository groupRepository;
@@ -36,22 +35,19 @@ class DiaryCreateApiTest extends ApiBaseTest {
     private DiaryRepository diaryRepository;
     @Autowired
     private UploadImageRepository uploadImageRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void 일기_작성_성공_사진포함() throws JsonProcessingException {
         Group group = createGroup(1);
-        groupRepository.save(group);
-        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
-        memberRepository.save(member);
+        updateSelf(group, 1);
         Map<String, String> data = makeDiaryData();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonData = objectMapper.writeValueAsString(data);
 
         Long diaryId = Long.parseLong(
                 RestAssured
                         .given().log().all()
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .multiPart("data", jsonData, "application/json")
+                        .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
                         .multiPart("file", new File("src/test/resources/images/test.jpg"), "image/png")
                         .cookie("token", token)
                         .when().post(String.format(API_PATH, group.getId()))
@@ -74,18 +70,14 @@ class DiaryCreateApiTest extends ApiBaseTest {
     @Test
     void 일기_작성_성공_사진_미포함() throws JsonProcessingException {
         Group group = createGroup(1);
-        groupRepository.save(group);
-        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
-        memberRepository.save(member);
+        updateSelf(group, 1);
         Map<String, String> data = makeDiaryData();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonData = objectMapper.writeValueAsString(data);
 
         Long diaryId = Long.parseLong(
                 RestAssured
                         .given().log().all()
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .multiPart("data", jsonData, "application/json")
+                        .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
                         .cookie("token", token)
                         .when().post(String.format(API_PATH, group.getId()))
                         .then().log().all()
@@ -105,17 +97,13 @@ class DiaryCreateApiTest extends ApiBaseTest {
     @Test
     void 일기_작성_실패_오늘작성완료() throws JsonProcessingException {
         Group group = createGroup(1);
-        groupRepository.save(group);
-        Diary diary = createDiary(group);
-        diaryRepository.save(diary);
+        createDiary(group);
         Map<String, String> data = makeDiaryData();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonData = objectMapper.writeValueAsString(data);
 
         RestAssured
                 .given().log().all()
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("data", jsonData, "application/json")
+                .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
                 .multiPart("file", new File("src/test/resources/images/test.jpg"), "image/png")
                 .cookie("token", token)
                 .when().post(String.format(API_PATH, group.getId()))
@@ -124,24 +112,20 @@ class DiaryCreateApiTest extends ApiBaseTest {
                 .body("message", equalTo(ErrorCode.DIARY_DUPLICATED.getMessage()));
     }
 
-    @DisplayName("일기 작성시 그룹내 순서 갱신")
     @Test
+    @DisplayName("일기 작성시 그룹내 순서 갱신")
     void 일기_작성_성공_순서_확인() throws JsonProcessingException {
         Group group = createGroup(1);
-        groupRepository.save(group);
-        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
-        Member groupMember = createMemberInGroup(group);
-        Member groupMember2 = createMemberInGroup(group);
-        memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));
+        updateSelf(group, 1);
+        createMember(group, 2);
+        createMember(group, 3);
         Map<String, String> data = makeDiaryData();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonData = objectMapper.writeValueAsString(data);
 
         Long diaryId = Long.parseLong(
                 RestAssured
                         .given().log().all()
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .multiPart("data", jsonData, "application/json")
+                        .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
                         .multiPart("file", new File("src/test/resources/images/test.jpg"), "image/png")
                         .cookie("token", token)
                         .when().post(String.format(API_PATH, group.getId()))
@@ -161,24 +145,20 @@ class DiaryCreateApiTest extends ApiBaseTest {
         assertThat(newDiary.getMoodLocation()).isEqualTo(data.get("moodLocation"));
     }
 
-    @DisplayName("일기 작성시 그룹내 순서 갱신 - 마지막 순서에서 첫번째 순서로 갱신")
     @Test
+    @DisplayName("일기 작성시 그룹내 순서 갱신 - 마지막 순서에서 첫번째 순서로 갱신")
     void 일기_작성_성공_순서_확인_맨_첫_순서로() throws JsonProcessingException {
         Group group = createGroup(3);
-        groupRepository.save(group);
-        member.joinGroup("api요청멤버", "orange", 3, GroupRole.GROUP_MEMBER, group);
-        Member groupMember = createMemberInGroup(group);
-        Member groupMember2 = createMemberInGroup(group);
-        memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));
+        updateSelf(group, 3);
+        createMember(group, 1);
+        createMember(group, 2);
         Map<String, String> data = makeDiaryData();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonData = objectMapper.writeValueAsString(data);
 
         Long diaryId = Long.parseLong(
                 RestAssured
                         .given().log().all()
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .multiPart("data", jsonData, "application/json")
+                        .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
                         .multiPart("file", new File("src/test/resources/images/test.jpg"), "image/png")
                         .cookie("token", token)
                         .when().post(String.format(API_PATH, group.getId()))
@@ -198,24 +178,20 @@ class DiaryCreateApiTest extends ApiBaseTest {
         assertThat(newDiary.getMoodLocation()).isEqualTo(data.get("moodLocation"));
     }
 
-    @DisplayName("일기 작성시 그룹내 순서 갱신 - 내용만 있는 경우")
     @Test
+    @DisplayName("일기 작성시 그룹내 순서 갱신 - 내용만 있는 경우")
     void 일기_작성_성공_순서_확인_내용만() throws JsonProcessingException {
         Group group = createGroup(1);
-        groupRepository.save(group);
-        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
-        Member groupMember = createMemberInGroup(group);
-        Member groupMember2 = createMemberInGroup(group);
-        memberRepository.saveAll(Arrays.asList(member, groupMember, groupMember2));
+        updateSelf(group, 1);
+        createMember(group, 2);
+        createMember(group, 3);
         Map<String, String> data = makeDiaryData();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonData = objectMapper.writeValueAsString(data);
 
         Long diaryId = Long.parseLong(
                 RestAssured
                         .given().log().all()
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .multiPart("data", jsonData, "application/json")
+                        .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
                         .cookie("token", token)
                         .when().post(String.format(API_PATH, group.getId()))
                         .then().log().all()
@@ -237,17 +213,13 @@ class DiaryCreateApiTest extends ApiBaseTest {
     @Test
     void 일기_작성_실패_이미지_형식_실패() throws JsonProcessingException {
         Group group = createGroup(1);
-        groupRepository.save(group);
-        member.joinGroup("api요청멤버", "orange", 1, GroupRole.GROUP_MEMBER, group);
-        memberRepository.save(member);
+        updateSelf(group, 1);
         Map<String, String> data = makeDiaryData();
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonData = objectMapper.writeValueAsString(data);
 
         RestAssured
                 .given().log().all()
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("data", jsonData, "application/json")
+                .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
                 .multiPart("file", new File("src/main/resources/static/images/character/red.svg"), "image/svg")
                 .cookie("token", token)
                 .when().post(String.format(API_PATH, group.getId()))
@@ -256,29 +228,62 @@ class DiaryCreateApiTest extends ApiBaseTest {
                 .body("message", equalTo(ErrorCode.INVALID_IMAGE_FORMAT.getMessage()));
     }
 
+    @Test
+    void 일기_작성_성공시_조회가능한_마지막_일기_날짜_업데이트_확인() throws JsonProcessingException {
+        Group group = createGroup(1);
+        updateSelf(group, 1);
+        member.updateLastViewableDiaryDate(LocalDate.now().minusMonths(1));
+        Member nextMember = createMember(group, 2);
+        Map<String, String> data = makeDiaryData();
+
+        RestAssured
+                .given().log().all()
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
+                .cookie("token", token)
+                .when().post(String.format(API_PATH, group.getId()))
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        Member writer = memberRepository.findById(this.member.getId()).get();
+        Member nextWriter = memberRepository.findById(nextMember.getId()).get();
+        assertThat(writer.getLastViewableDiaryDate()).isEqualTo(LocalDate.now());
+        assertThat(nextWriter.getLastViewableDiaryDate()).isEqualTo(LocalDate.now());
+    }
+
     private Diary createDiary(Group group) {
-        return Diary.builder()
+        Diary diary = Diary.builder()
                 .content("하이하이")
                 .moodLocation("/images/write-page/emoji/sleepy.svg")
                 .group(group)
                 .build();
+        return diaryRepository.save(diary);
     }
 
     private Group createGroup(int currentOrder) {
-        return Group.builder()
+        Group group = Group.builder()
                 .name("버니즈")
                 .currentOrder(currentOrder)
                 .code("code")
                 .lastSkipOrderDate(LocalDate.now())
                 .build();
+        return groupRepository.save(group);
     }
 
-    private Member createMemberInGroup(Group group) {
-        return Member.builder()
+    private void updateSelf(Group group, int order) {
+        member.joinGroup("api요청멤버", "orange", order, GroupRole.GROUP_MEMBER, group);
+        memberRepository.save(member);
+    }
+
+    private Member createMember(Group group, int order) {
+        Member member = Member.builder()
                 .kakaoId(12345L)
                 .profileImage("red")
+                .lastViewableDiaryDate(LocalDate.now().minusDays(1))
+                .orderInGroup(order)
                 .group(group)
                 .build();
+        return memberRepository.save(member);
     }
 
     private Map<String, String> makeDiaryData() {

--- a/src/test/java/com/exchangediary/diary/domain/DiaryRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/diary/domain/DiaryRepositoryUnitTest.java
@@ -2,6 +2,8 @@ package com.exchangediary.diary.domain;
 
 import com.exchangediary.diary.domain.entity.Diary;
 import com.exchangediary.diary.domain.entity.UploadImage;
+import com.exchangediary.member.domain.MemberRepository;
+import com.exchangediary.member.domain.entity.Member;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
@@ -11,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,6 +25,8 @@ public class DiaryRepositoryUnitTest {
     private DiaryRepository diaryRepository;
     @Autowired
     private UploadImageRepository uploadImageRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
     private byte[] getBinaryImage() {
         try {
@@ -67,5 +72,41 @@ public class DiaryRepositoryUnitTest {
 
         boolean exist = uploadImageRepository.findById(uploadImage.getId()).isPresent();
         assertThat(exist).isFalse();
+    }
+
+    @Test
+    void 일기_조회_가능() {
+        Diary diary = Diary.builder()
+                .content("하이하이")
+                .moodLocation("/images/write-page/emoji/sleepy.svg")
+                .build();
+        diaryRepository.save(diary);
+        Member member = Member.builder()
+                .kakaoId(1234L)
+                .lastViewableDiaryDate(LocalDate.now())
+                .build();
+        memberRepository.save(member);
+
+        boolean result = diaryRepository.isViewableDiary(member.getId(), diary.getId());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 일기_조회_불가능() {
+        Diary diary = Diary.builder()
+                .content("하이하이")
+                .moodLocation("/images/write-page/emoji/sleepy.svg")
+                .build();
+        diaryRepository.save(diary);
+        Member member = Member.builder()
+                .kakaoId(1234L)
+                .lastViewableDiaryDate(LocalDate.now().minusMonths(1))
+                .build();
+        memberRepository.save(member);
+
+        boolean result = diaryRepository.isViewableDiary(member.getId(), diary.getId());
+
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/com/exchangediary/global/config/interceptor/ViewDiaryAuthorizationInterceptorTest.java
+++ b/src/test/java/com/exchangediary/global/config/interceptor/ViewDiaryAuthorizationInterceptorTest.java
@@ -1,0 +1,73 @@
+package com.exchangediary.global.config.interceptor;
+
+import com.exchangediary.ApiBaseTest;
+import com.exchangediary.diary.domain.DiaryRepository;
+import com.exchangediary.diary.domain.entity.Diary;
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.domain.entity.Group;
+import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.domain.enums.GroupRole;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+
+public class ViewDiaryAuthorizationInterceptorTest extends ApiBaseTest {
+    @Autowired
+    private DiaryRepository diaryRepository;
+    @Autowired
+    private GroupRepository groupRepository;
+
+
+    @Test
+    void 일기_조회_성공() {
+        Group group = createGroup();
+        updateSelf(group, LocalDate.now());
+        Diary diary = createDiary(this.member, group);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().get(String.format("/group/%d/diary/%d", group.getId(), diary.getId()))
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 일기_조회_실패() {
+        Group group = createGroup();
+        updateSelf(group, LocalDate.now().minusDays(1));
+        Diary diary = createDiary(this.member, group);
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .redirects().follow(false)
+                .when().get(String.format("/group/%d/diary/%d", group.getId(), diary.getId()))
+                .then().log().all()
+                .statusCode(HttpStatus.FOUND.value());
+    }
+
+    private Group createGroup() {
+        Group group = Group.of("groupname", "code");
+        return groupRepository.save(group);
+    }
+
+    private void updateSelf(Group group, LocalDate lastViewableDiaryDate) {
+        this.member.joinGroup("nickname", "red", 1, GroupRole.GROUP_MEMBER, group);
+        this.member.updateLastViewableDiaryDate(lastViewableDiaryDate);
+        memberRepository.save(this.member);
+    }
+
+    private Diary createDiary(Member member, Group group) {
+        Diary diary = Diary.builder()
+                .content("content")
+                .moodLocation("mood-location")
+                .member(member)
+                .group(group)
+                .build();
+        return diaryRepository.save(diary);
+    }
+}

--- a/src/test/java/com/exchangediary/global/config/interceptor/WriteDiaryAuthorizationInterceptorTest.java
+++ b/src/test/java/com/exchangediary/global/config/interceptor/WriteDiaryAuthorizationInterceptorTest.java
@@ -121,7 +121,7 @@ public class WriteDiaryAuthorizationInterceptorTest extends ApiBaseTest {
     }
 
     private void updateSelf(Group group, int order) {
-        this.member.updateMemberGroupInfo(
+        this.member.joinGroup(
                 "me",
                 "red",
                 order,

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import java.time.LocalDate;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GroupLeaderHandOverApiTest extends ApiBaseTest {
@@ -64,7 +62,7 @@ public class GroupLeaderHandOverApiTest extends ApiBaseTest {
     }
 
     private void updateSelf(Group group, int order, GroupRole role) {
-        this.member.updateMemberGroupInfo(
+        this.member.joinGroup(
                 "me",
                 "red",
                 order,

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
@@ -70,7 +70,7 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
     }
 
     private void updateSelf(Group group, int order, GroupRole role) {
-        this.member.updateMemberGroupInfo(
+        this.member.joinGroup(
                 "me",
                 "red",
                 order,

--- a/src/test/java/com/exchangediary/group/api/GroupMembersOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupMembersOrderApiTest.java
@@ -28,7 +28,7 @@ public class GroupMembersOrderApiTest extends ApiBaseTest {
     void 그룹원_순서_조회_내순서_1번일때() {
         Group group = createGroup();
         groupRepository.save(group);
-        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 1, GroupRole.GROUP_MEMBER, group);
+        this.member.joinGroup("self", PROFILE_IMAGES.get(0), 1, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         for (int idx = 6; idx > 0; idx--) {
             Member member = createMember(group, idx + 1, PROFILE_IMAGES.get(7 - idx));
@@ -60,7 +60,7 @@ public class GroupMembersOrderApiTest extends ApiBaseTest {
     void 그룹원_순서_조회_내순서_4번일때() {
         Group group = createGroup();
         groupRepository.save(group);
-        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 4, GroupRole.GROUP_MEMBER, group);
+        this.member.joinGroup("self", PROFILE_IMAGES.get(0), 4, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         for (int idx = 3; idx > 0; idx--) {
             Member member = createMember(group, idx, PROFILE_IMAGES.get(7 - idx));
@@ -96,7 +96,7 @@ public class GroupMembersOrderApiTest extends ApiBaseTest {
     void 그룹원_순서_조회_내순서_7번일때() {
         Group group = createGroup();
         groupRepository.save(group);
-        this.member.updateMemberGroupInfo("self", PROFILE_IMAGES.get(0), 7, GroupRole.GROUP_MEMBER, group);
+        this.member.joinGroup("self", PROFILE_IMAGES.get(0), 7, GroupRole.GROUP_MEMBER, group);
         memberRepository.save(member);
         for (int idx = 6; idx > 0; idx--) {
             Member member = createMember(group, idx, PROFILE_IMAGES.get(7 - idx));

--- a/src/test/java/com/exchangediary/group/domain/GroupRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/group/domain/GroupRepositoryUnitTest.java
@@ -24,7 +24,7 @@ public class GroupRepositoryUnitTest {
     void 내_그룹순서가_현재_그룹순서와_일치하는지_확인() {
         Group group = Group.of("버니즈", "code");
         Member member = Member.from(1L);
-        member.updateMemberGroupInfo("nickname", "red", 1, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("nickname", "red", 1, GroupRole.GROUP_MEMBER, group);
         entityManager.persist(group);
         entityManager.persist(member);
 
@@ -38,7 +38,7 @@ public class GroupRepositoryUnitTest {
     void 내_그룹순서가_현재_그룹순서와_일치_안함() {
         Group group = Group.of("버니즈", "code");
         Member member = Member.from(1L);
-        member.updateMemberGroupInfo("nickname", "red", 2, GroupRole.GROUP_MEMBER, group);
+        member.joinGroup("nickname", "red", 2, GroupRole.GROUP_MEMBER, group);
         entityManager.persist(group);
         entityManager.persist(member);
 


### PR DESCRIPTION
## Work Description
> 일기 조회 인가 구현

- 일기 조회를 위해서 멤버 엔티티에 조회 가능한 마지막 일기 날짜(`lastViewableDiaryDate`) 필드를 추가했습니다.
  - 새로운 일기 추가 시, 일기 작성자와 그 다음 일기 작성자의 `lastViewableDiaryDate` 필드가 일기 작성일자로 업데이트됩니다.
- 일기 조회 인가 인터셉터를 구현했습니다.
- webConfig에 일기 조회 url(`/group/{groupId}/diary`)에 일기 조회 인가 인터셉터를 거치도록 추가했습니다.
- 일기 조회 인가 인터셉터 테스트를 추가했습니다.

## ISSUE
- closed #254


## Screenshot
#### 일기 작성 로직에 `lastViewableDiaryDate` 필드 업데이트 검증 테스트 추가
<img width="453" alt="Screenshot 2024-10-24 at 9 49 52 PM" src="https://github.com/user-attachments/assets/accfefb3-ae8a-4180-b98a-bae425d4b584">

#### 일기 조회 인가 인터셉터 테스트 결과
<img width="452" alt="Screenshot 2024-10-24 at 9 49 28 PM" src="https://github.com/user-attachments/assets/24146ee9-1efa-4142-b715-0ea18cda1600">
