### PR TITLE
방장 권한 넘기기 API 수정

### DIFF
--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -21,7 +21,7 @@ public class GroupLeaderService {
     public void handOverGroupLeader(Long groupId, Long memberId, GroupLeaderHandOverRequest request) {
         Group group = groupQueryService.findGroup(groupId);
         Member currentLeader = groupMemberService.findSelfInGroup(group, memberId);
-        Member newLeader = findGroupMemberByIndex(group, request.nextLeaderIndex());
+        Member newLeader = groupMemberService.findMemberByNickname(group, request.nickname());
 
         currentLeader.changeGroupRole(GroupRole.GROUP_MEMBER);
         newLeader.changeGroupRole(GroupRole.GROUP_LEADER);
@@ -32,17 +32,5 @@ public class GroupLeaderService {
         groupValidationService.checkSkipOrderAuthority(group);
         group.updateCurrentOrder(group.getCurrentOrder() + 1, group.getMembers().size());
         group.updateLastSkipOrderDate();
-    }
-
-    private Member findGroupMemberByIndex(Group group, int index) {
-        try {
-            return group.getMembers().get(index);
-        } catch (RuntimeException exception) {
-            throw new NotFoundException(
-                    ErrorCode.MEMBER_NOT_FOUND,
-                    "",
-                    String.valueOf(index)
-            );
-        }
     }
 }

--- a/src/main/java/com/exchangediary/group/service/GroupMemberService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupMemberService.java
@@ -44,4 +44,16 @@ public class GroupMemberService {
         }
         return group.getMembers().get(group.getCurrentOrder() - 1);
     }
+
+    public Member findMemberByNickname(Group group, String nickname) {
+        return group.getMembers().stream()
+                .filter(member -> member.getNickname().equals(nickname))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(
+                        ErrorCode.MEMBER_NOT_FOUND,
+                        "",
+                        nickname
+                ));
+
+    }
 }

--- a/src/main/java/com/exchangediary/group/ui/dto/request/GroupLeaderHandOverRequest.java
+++ b/src/main/java/com/exchangediary/group/ui/dto/request/GroupLeaderHandOverRequest.java
@@ -1,8 +1,8 @@
 package com.exchangediary.group.ui.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record GroupLeaderHandOverRequest(
-        @NotNull Integer nextLeaderIndex
+        @NotBlank String nickname
 ){
 }

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderHandOverApiTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import java.time.LocalDate;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GroupLeaderHandOverApiTest extends ApiBaseTest {
@@ -33,7 +31,7 @@ public class GroupLeaderHandOverApiTest extends ApiBaseTest {
                 .given().log().all()
                 .cookie("token", token)
                 .contentType(ContentType.JSON)
-                .body(new GroupLeaderHandOverRequest(member.getOrderInGroup() - 1))
+                .body(new GroupLeaderHandOverRequest("group-member"))
                 .when().patch(String.format("/api/groups/%s/leader/hand-over", group.getId()))
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
@@ -53,7 +51,7 @@ public class GroupLeaderHandOverApiTest extends ApiBaseTest {
                 .given().log().all()
                 .cookie("token", token)
                 .contentType(ContentType.JSON)
-                .body(new GroupLeaderHandOverRequest(1))
+                .body(new GroupLeaderHandOverRequest("invalid-nickname"))
                 .when().patch(String.format("/api/groups/%s/leader/hand-over", group.getId()))
                 .then().log().all()
                 .statusCode(HttpStatus.NOT_FOUND.value());


### PR DESCRIPTION
## Work Description
> 방장 권한 넘기기 API 수정

- 닉네임 요청받도록 수정
  - `AS-IS` : 방장 권한을 넘길 사용자의 그룹 내 인덱스
  - `TO-BE` : 방장 권한을 넘길 사용자의 닉네임 (그룹 내 유니크한 값)

## ISSUE
- closed #297


## Screenshot
#### 테스트 결과
<img width="439" alt="Screenshot 2024-10-25 at 3 25 14 PM" src="https://github.com/user-attachments/assets/421c7602-df10-472b-9f0f-4e633d215055">

