### PR TITLE
그룹원 정보 조회 API 수정

### DIFF
--- a/src/main/java/com/exchangediary/group/service/GroupMemberService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupMemberService.java
@@ -1,6 +1,5 @@
 package com.exchangediary.group.service;
 
-import com.exchangediary.diary.domain.DiaryRepository;
 import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.global.exception.serviceexception.NotFoundException;
 import com.exchangediary.group.domain.entity.Group;
@@ -14,8 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GroupMemberService {
-    private final DiaryRepository diaryRepository;
-
     public Member findSelfInGroup(Group group, Long memberId) {
         return group.getMembers().stream()
                 .filter(member -> memberId.equals(member.getId()))
@@ -36,13 +33,6 @@ public class GroupMemberService {
                         "",
                         String.valueOf(group.getId())
                 ));
-    }
-
-    public Member findMemberHasWriteAuthority(Group group) {
-        if (diaryRepository.existsTodayDiaryInGroup(group.getId())) {
-            return group.getMembers().get(group.getCurrentOrder() - 2);
-        }
-        return group.getMembers().get(group.getCurrentOrder() - 1);
     }
 
     public Member findMemberByNickname(Group group, String nickname) {

--- a/src/main/java/com/exchangediary/group/service/GroupQueryService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupQueryService.java
@@ -53,12 +53,11 @@ public class GroupQueryService {
         Group group = findGroup(groupId);
         Member self = groupMemberService.findSelfInGroup(group, memberId);
         Member leader = groupMemberService.findGroupLeader(group);
-        Member currentWriter = groupMemberService.findMemberHasWriteAuthority(group);
         return GroupMembersResponse.of(
                 group.getMembers(),
                 self.getOrderInGroup() - 1,
                 leader.getOrderInGroup() - 1,
-                currentWriter.getOrderInGroup() - 1
+                group.getCurrentOrder() - 1
         );
     }
 

--- a/src/test/java/com/exchangediary/group/api/GroupMembersOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupMembersOrderApiTest.java
@@ -161,7 +161,7 @@ public class GroupMembersOrderApiTest extends ApiBaseTest {
         assertThat(members.get(6).nickname()).isEqualTo("name7");
         assertThat(response.selfIndex()).isEqualTo(0);
         assertThat(response.leaderIndex()).isEqualTo(0);
-        assertThat(response.currentWriterIndex()).isEqualTo(0);
+        assertThat(response.currentWriterIndex()).isEqualTo(1);
     }
 
     private Group createGroup() {


### PR DESCRIPTION
## Work Description
> 그룹원 정보 조회 API 수정

- 현재 일기 작성자를 현재 그룹 순서와 일치하는 사용자로 변경했습니다.
  - 이유는 이슈 코멘트 참고

## ISSUE
- closed #303


## Screenshot
<img width="457" alt="Screenshot 2024-10-25 at 10 48 03 PM" src="https://github.com/user-attachments/assets/8ed88bba-51f5-497d-a934-bb77ceab4c00">
