### PR TITLE
일기 건너뛰기 API 오류 해결

### DIFF
--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -36,6 +38,8 @@ public class GroupLeaderService {
         groupValidationService.checkSkipOrderAuthority(group);
         group.updateCurrentOrder(group.getCurrentOrder() + 1, group.getMembers().size());
         group.updateLastSkipOrderDate();
+        Member currentWriter = groupMemberService.findCurrentOrderMember(group);
+        currentWriter.updateLastViewableDiaryDate(LocalDate.now());
     }
 
     public void kickOutMember(Long groupId, GroupKickOutRequest request) {

--- a/src/main/java/com/exchangediary/group/service/GroupMemberService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupMemberService.java
@@ -54,6 +54,16 @@ public class GroupMemberService {
                         "",
                         nickname
                 ));
+    }
 
+    public Member findCurrentOrderMember(Group group) {
+        return group.getMembers().stream()
+                .filter(member -> group.getCurrentOrder().equals(member.getOrderInGroup()))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(
+                        ErrorCode.MEMBER_NOT_FOUND,
+                        "",
+                        String.valueOf(group.getCurrentOrder())
+                ));
     }
 }

--- a/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaderSkipOrderApiTest.java
@@ -22,9 +22,9 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
 
     @Test
     void 일기_건너뛰기_성공() {
-        Group group = createGroup(2);
+        Group group = createGroup(1);
         updateSelf(group, 1, GroupRole.GROUP_LEADER);
-        createMember(group, 2, GroupRole.GROUP_MEMBER);
+        Member member = createMember(group, 2, GroupRole.GROUP_MEMBER);
 
         RestAssured
                 .given().log().all()
@@ -34,8 +34,10 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
                 .statusCode(HttpStatus.OK.value());
 
         Group updatedGroup = groupRepository.findById(group.getId()).get();
-        assertThat(updatedGroup.getCurrentOrder()).isEqualTo(1);
+        assertThat(updatedGroup.getCurrentOrder()).isEqualTo(2);
         assertThat(updatedGroup.getLastSkipOrderDate()).isEqualTo(LocalDate.now());
+        Member currentWriter = memberRepository.findById(member.getId()).get();
+        assertThat(currentWriter.getLastViewableDiaryDate()).isEqualTo(LocalDate.now());
     }
 
     @Test
@@ -86,6 +88,7 @@ public class GroupLeaderSkipOrderApiTest extends ApiBaseTest {
                 .nickname("group-member")
                 .profileImage("orange")
                 .orderInGroup(order)
+                .lastViewableDiaryDate(LocalDate.now().minusMonths(1))
                 .group(group)
                 .groupRole(role)
                 .build()


### PR DESCRIPTION
## Work Description
> 일기 건너뛰기 API 오류 해결

- 일기 건너뛰기 시, 
순서 넘겨받은 사용자의 조회 가능한 마지막 일기 날짜(`lastViewableDiaryDate`) 필드가 업데이트되지 않는 오류가 있어 해결했습니다.

## ISSUE
- closed #306 


## Screenshot
#### 테스트 결과
<img width="451" alt="Screenshot 2024-10-26 at 1 17 31 AM" src="https://github.com/user-attachments/assets/5cca424c-bb3a-4ffe-80bf-3da3a0c24307">
