### PR TITLE
백엔드 에러 로깅 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ out/
 
 application.yml
 application.properties
+
+/log

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'

--- a/src/main/java/com/exchangediary/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/exchangediary/global/exception/GlobalExceptionHandler.java
@@ -1,13 +1,7 @@
 package com.exchangediary.global.exception;
 
-import com.exchangediary.global.exception.serviceexception.ConfilctException;
-import com.exchangediary.global.exception.serviceexception.FailedImageUploadException;
-import com.exchangediary.global.exception.serviceexception.KakaoLoginFailureException;
-import com.exchangediary.global.exception.serviceexception.DuplicateException;
 import com.exchangediary.global.exception.serviceexception.ServiceException;
-import com.exchangediary.global.exception.serviceexception.InvalidDateException;
-import com.exchangediary.global.exception.serviceexception.NotFoundException;
-import com.exchangediary.global.exception.serviceexception.UnauthorizedException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -19,11 +13,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.Objects;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(code = HttpStatus.BAD_REQUEST)
     public ApiErrorResponse handleInvalidArgumentException(MethodArgumentNotValidException exception) {
         try {
+            log.error("{}", String.format("%s", exception.getFieldError().getDefaultMessage()));
             return ApiErrorResponse.from(Objects.requireNonNull(exception.getFieldError()));
         } catch (NullPointerException e) {
             return ApiErrorResponse.from(HttpStatus.BAD_REQUEST);
@@ -38,6 +34,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ServiceException.class)
     public ResponseEntity<ApiErrorResponse> handleServiceException(ServiceException exception) {
+        log.error("{} caused by {}", exception.toString(), exception.getValue());
+
         ApiErrorResponse body = ApiErrorResponse.from(
                 exception.getErrorCode(),
                 exception.getMessage(),

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/buddies-spring-error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,0 +1,13 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/buddies-spring-info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/jdbc-appender.xml
+++ b/src/main/resources/jdbc-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE-JDBC" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${JDBC_CONSOLE_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/jdbc-loggers.xml
+++ b/src/main/resources/jdbc-loggers.xml
@@ -1,14 +1,8 @@
 <included>
-    <logger name="jdbc" level="OFF" additivity="false">
-        <appender-ref ref="CONSOLE-JDBC"/>
-    </logger>
+    <logger name="jdbc" level="DEBUG" additivity="false"/>
+    <logger name="jdbc.sqltiming" level="DEBUG" additivity="false"/>
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false"/>
     <logger name="jdbc.sqlonly" level="DEBUG" additivity="false">
-        <appender-ref ref="CONSOLE-JDBC"/>
-    </logger>
-    <logger name="jdbc.sqltiming" level="OFF" additivity="false">
-        <appender-ref ref="CONSOLE-JDBC"/>
-    </logger>
-    <logger name="org.hibernate.SQL" level="OFF" additivity="false">
         <appender-ref ref="CONSOLE-JDBC"/>
     </logger>
 </included>

--- a/src/main/resources/jdbc-loggers.xml
+++ b/src/main/resources/jdbc-loggers.xml
@@ -1,0 +1,14 @@
+<included>
+    <logger name="jdbc" level="OFF" additivity="false">
+        <appender-ref ref="CONSOLE-JDBC"/>
+    </logger>
+    <logger name="jdbc.sqlonly" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE-JDBC"/>
+    </logger>
+    <logger name="jdbc.sqltiming" level="OFF" additivity="false">
+        <appender-ref ref="CONSOLE-JDBC"/>
+    </logger>
+    <logger name="org.hibernate.SQL" level="OFF" additivity="false">
+        <appender-ref ref="CONSOLE-JDBC"/>
+    </logger>
+</included>

--- a/src/main/resources/log4jdbc.log4j2.properties
+++ b/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,2 @@
+log4jdbc.spylogdelegator.name = net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength = 0

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,11 +1,41 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="CONSOLE_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %highlight([%-3level]) %logger{5} : %msg%n" />
+    <property name="CONSOLE_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %highlight([%-3level]) %logger{5}: %msg%n" />
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%-3level] %logger{5}: %msg%n"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <Pattern>${CONSOLE_PATTERN}</Pattern>
         </encoder>
+    </appender>
+
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/buddies-spring-info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/buddies-spring-error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
     </appender>
 
     <logger name="jdbc" level="OFF" additivity="false">
@@ -23,5 +53,7 @@
 
     <root level="info">
         <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE-INFO"/>
+        <appender-ref ref="FILE-ERROR"/>
     </root>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,26 +2,26 @@
 <configuration>
     <property name="CONSOLE_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %highlight([%-3level]) %logger{5} : %msg%n" />
 
-    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <Pattern>${CONSOLE_PATTERN}</Pattern>
         </encoder>
     </appender>
 
     <logger name="jdbc" level="OFF" additivity="false">
-        <appender-ref ref="console"/>
+        <appender-ref ref="CONSOLE"/>
     </logger>
     <logger name="jdbc.sqlonly" level="DEBUG" additivity="false">
-        <appender-ref ref="console"/>
+        <appender-ref ref="CONSOLE"/>
     </logger>
     <logger name="jdbc.sqltiming" level="OFF" additivity="false">
-        <appender-ref ref="console"/>
+        <appender-ref ref="CONSOLE"/>
     </logger>
     <logger name="org.hibernate.SQL" level="OFF" additivity="false">
-        <appender-ref ref="console"/>
+        <appender-ref ref="CONSOLE"/>
     </logger>
-    <root level="info">
-        <appender-ref ref="console" />
-    </root>
 
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -18,8 +18,13 @@
     <!--dev-->
     <springProfile name="dev">
         <include resource="file-info-appender.xml"/>
-        <include resource="jdbc-appender.xml"/>
-        <include resource="jdbc-loggers.xml"/>
+
+        <logger name="jdbc" level="DEBUG" additivity="false"/>
+        <logger name="jdbc.sqltiming" level="DEBUG" additivity="false"/>
+        <logger name="org.hibernate.SQL" level="DEBUG" additivity="false"/>
+        <logger name="jdbc.sqlonly" level="DEBUG" additivity="false">
+            <appender-ref ref="FILE-INFO"/>
+        </logger>
 
         <root level="INFO">
             <appender-ref ref="FILE-INFO"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <property name="CONSOLE_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %highlight([%-3level]) %logger{5} : %msg%n" />
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+
+    <logger name="jdbc" level="OFF" additivity="false">
+        <appender-ref ref="console"/>
+    </logger>
+    <logger name="jdbc.sqlonly" level="DEBUG" additivity="false">
+        <appender-ref ref="console"/>
+    </logger>
+    <logger name="jdbc.sqltiming" level="OFF" additivity="false">
+        <appender-ref ref="console"/>
+    </logger>
+    <logger name="org.hibernate.SQL" level="OFF" additivity="false">
+        <appender-ref ref="console"/>
+    </logger>
+    <root level="info">
+        <appender-ref ref="console" />
+    </root>
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,59 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="CONSOLE_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %highlight([%-3level]) %logger{5}: %msg%n" />
+    <property name="CONSOLE_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %highlight([%-3level]) %green(%logger{5}): %msg%n"/>
+    <property name="JDBC_CONSOLE_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %highlight([%-3level]) %yellow(%logger{5}):%msg"/>
     <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%-3level] %logger{5}: %msg%n"/>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <Pattern>${CONSOLE_PATTERN}</Pattern>
-        </encoder>
-    </appender>
+    <!--local-->
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+        <include resource="jdbc-appender.xml"/>
+        <include resource="jdbc-loggers.xml"/>
 
-    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <encoder>
-            <pattern>${FILE_LOG_PATTERN}</pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/buddies-spring-info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
-            <maxHistory>10</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
-    </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
 
-    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>ERROR</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-        <encoder>
-            <pattern>${FILE_LOG_PATTERN}</pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/buddies-spring-error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>3GB</totalSizeCap>
-        </rollingPolicy>
-    </appender>
+    <!--dev-->
+    <springProfile name="dev">
+        <include resource="file-info-appender.xml"/>
+        <include resource="jdbc-appender.xml"/>
+        <include resource="jdbc-loggers.xml"/>
 
-    <logger name="jdbc" level="OFF" additivity="false">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-    <logger name="jdbc.sqlonly" level="DEBUG" additivity="false">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-    <logger name="jdbc.sqltiming" level="OFF" additivity="false">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-    <logger name="org.hibernate.SQL" level="OFF" additivity="false">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+        </root>
+    </springProfile>
 
-    <root level="info">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE-INFO"/>
-        <appender-ref ref="FILE-ERROR"/>
-    </root>
+    <!--prod-->
+    <springProfile name="prod">
+        <include resource="file-info-appender.xml"/>
+        <include resource="file-error-appender.xml"/>
+
+        <root level="ERROR">
+            <appender-ref ref="FILE-ERROR"/>
+        </root>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
## Work Description
> 백엔드 에러 로깅 추가

- `logback`와 `log4j2` 중 `logback` 라이브러리를 선택했습니다.
  - `log4j2` 라이브러리는 비동기 로깅, Loom 백그라운드 로깅을 지원하고, `logback`보다 성능이 좋다고 알고 있지만
저희 서비스에서 위와 같은 기능을 지원하는 로깅까지 필요없다고 판단하여 `logback` 라이브러리를 선택했습니다.
- `log4jdbc` 의존성과 `log4jdbc.log4j2.properties` 설정파일을 추가하여, 
실제 sql 쿼리문 로그를 볼 수 있도록 하였습니다.
- 로컬, 개발서버, 실제서버에 따라서 다른 로그를 출력할 수 있도록 설정했습니다.
  - `local`은 콘솔에 sql query와 info 이상 레벨의 로그를 출력합니다.
  - `dev`(개발 서버)는 info 파일에 sql query와 info 이상 레벨의 로그를 출력합니다.
  - `prod`(배포 서버)는 info 파일에 info 이상의 레벨 로그를 출력하고, error 파일에 error 이상의 레벨 로그를 출력합니다.


## ISSUE
- closed #337 

## To Reviewers
- 현재 서버가 어떤 환경의 서버인지를 구분하기 위해서 application.properties 파일에 아래 설정 추가 부탁드려요!!
```text
spring.profiles.active=local #dev, prod
```
- API 예외가 발생한 경우에 대해서 error 레벨의 로그가 발생하도록 설정해놓았습니다.
예외 클래스, 예외 메시지, 예외 발생 이유/값(value)가 나타날 수 있도록 아래와 같이 메시지를 설정해놓았는데, 어떤지 의견 부탁드려요!
```text
2024-10-30 17:54:33.788 [http-nio-8080-exec-2] [ERROR] c.e.g.e.GlobalExceptionHandler: com.exchangediary.global.exception.serviceexception.InvalidDateException: 유효하지 않은 날짜입니다. caused by 2024-09-38
```

## Reference
[Spring Boot 로그(Log) 남기기. Log4j2을 사용한 로깅 전략](https://yeo-computerclass.tistory.com/552)
[Logback을 이용해 운영 환경 별 로그 남기기](https://blog.pium.life/server-logging/)
[[Spring boot] Logback을 사용하여 쿼리 로그 출력](https://velog.io/@hjeu/Spring-boot-Logback%EC%9D%84-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-%EC%BF%BC%EB%A6%AC-%EB%A1%9C%EA%B7%B8-%EC%B6%9C%EB%A0%A5)
[[JAVA] e.toString(), e.getMessage(), e.printStackTrace() 예외처리](https://lnsideout.tistory.com/entry/JAVA-etoString-egetMessage-eprintStackTrace-%EC%98%88%EC%99%B8%EC%B2%98%EB%A6%AC)
[Spring Profile 과 application.properties](https://velog.io/@rolroralra/Spring-Profile-%EA%B3%BC-application.properties#%EC%8B%A4%ED%96%89-%EC%8B%9C-profile-%EC%84%A4%EC%A0%95-%EB%B0%A9%EB%B2%95)