### PR TITLE
그룹 탈퇴 시, 조회 가능한 마지막 일기 날짜 업데이트 오류 해결

### DIFF
--- a/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.Arrays;
 
 @Service

--- a/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
@@ -45,7 +45,7 @@ public class DiaryWriteService {
             uploadImage(file, diary);
             updateGroupCurrentOrder(group);
             updateViewableDiaryDate(member, group);
-            member.updateLastViewableDiaryDate(LocalDate.now());
+            member.updateLastViewableDiaryDate();
 
             Diary savedDiary = diaryRepository.save(diary);
             return savedDiary.getId();
@@ -81,8 +81,8 @@ public class DiaryWriteService {
                         .findFirst()
                         .get();
 
-        nextWriter.updateLastViewableDiaryDate(LocalDate.now());
-        currentWriter.updateLastViewableDiaryDate(LocalDate.now());
+        nextWriter.updateLastViewableDiaryDate();
+        currentWriter.updateLastViewableDiaryDate();
         memberRepository.saveAll(Arrays.asList(currentWriter, nextWriter));
     }
 }

--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -39,7 +39,7 @@ public class GroupLeaderService {
         group.updateCurrentOrder(group.getCurrentOrder() + 1, group.getMembers().size());
         group.updateLastSkipOrderDate();
         Member currentWriter = groupMemberService.findCurrentOrderMember(group);
-        currentWriter.updateLastViewableDiaryDate(LocalDate.now());
+        currentWriter.updateLastViewableDiaryDate();
     }
 
     public void kickOutMember(Long groupId, GroupKickOutRequest request) {

--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-
 @Service
 @RequiredArgsConstructor
 @Transactional

--- a/src/main/java/com/exchangediary/group/service/GroupLeaveService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaveService.java
@@ -74,6 +74,19 @@ public class GroupLeaveService {
         } else {
             group.updateCurrentOrder(currentOrder, numberOfGroupMember);
         }
+
+        if (leaveMemberOrder == currentOrder) {
+            int index = getCurrentMemberIndex(group.getCurrentOrder());
+            group.getMembers().get(index).updateLastViewableDiaryDate();
+        }
+
         groupRepository.save(group);
+    }
+
+    private int getCurrentMemberIndex(int currentOrder) {
+        if (currentOrder == 1) {
+            return 0;
+        }
+        return currentOrder;
     }
 }

--- a/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -82,8 +82,8 @@ public class Member extends BaseEntity {
         this.groupRole = groupRole;
     }
 
-    public void updateLastViewableDiaryDate(LocalDate lastViewableDiaryDate) {
-        this.lastViewableDiaryDate = lastViewableDiaryDate;
+    public void updateLastViewableDiaryDate() {
+        this.lastViewableDiaryDate = LocalDate.now();
     }
 
     public void updateOrderInGroup(Integer orderInGroup) { this.orderInGroup = orderInGroup; }

--- a/src/test/java/com/exchangediary/diary/api/DiaryViewMonthlyTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryViewMonthlyTest.java
@@ -16,8 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import java.time.LocalDate;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -32,7 +30,7 @@ class DiaryViewMonthlyTest extends ApiBaseTest {
     @DisplayName("사용자가 오늘 일기까지 조회 가능")
     void 달력형_일기_조회_성공_조회_가능한_일기() {
         Group group = createGroup();
-        updateSelf(group, LocalDate.now());
+        updateSelf(group, true);
         Diary diary = createDiary(group);
 
         DiaryMonthlyResponse response = RestAssured
@@ -57,7 +55,7 @@ class DiaryViewMonthlyTest extends ApiBaseTest {
     @DisplayName("사용자가 어제 일기까지 조회 가능")
     void 달력형_일기_조회_성공_조회_불가능한_일기() {
         Group group = createGroup();
-        updateSelf(group, LocalDate.now().minusDays(1));
+        updateSelf(group, false);
         Diary diary = createDiary(group);
 
         DiaryMonthlyResponse response = RestAssured
@@ -81,7 +79,7 @@ class DiaryViewMonthlyTest extends ApiBaseTest {
     @Test
     void 달력형_일기_조회_실패_날짜_유효성_검사() {
         Group group = createGroup();
-        updateSelf(group, LocalDate.now().minusDays(1));
+        updateSelf(group, true);
 
         RestAssured
                 .given().log().all()
@@ -99,9 +97,11 @@ class DiaryViewMonthlyTest extends ApiBaseTest {
         return groupRepository.save(Group.of("버니즈", "code"));
     }
 
-    private void updateSelf(Group group, LocalDate lastViewableDiaryDate) {
+    private void updateSelf(Group group, boolean canViewToday) {
         this.member.joinGroup("nickname", "/image", 1, GroupRole.GROUP_LEADER, group);
-        this.member.updateLastViewableDiaryDate(lastViewableDiaryDate);
+        if (canViewToday) {
+            member.updateLastViewableDiaryDate();
+        }
         memberRepository.save(member);
     }
 

--- a/src/test/java/com/exchangediary/diary/api/DiaryWriteApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryWriteApiTest.java
@@ -233,7 +233,6 @@ class DiaryWriteApiTest extends ApiBaseTest {
     void 일기_작성_성공시_조회가능한_마지막_일기_날짜_업데이트_확인() throws JsonProcessingException {
         Group group = createGroup(1);
         updateSelf(group, 1);
-        member.updateLastViewableDiaryDate(LocalDate.now().minusMonths(1));
         Member nextMember = createMember(group, 2);
         Map<String, String> data = makeDiaryData();
 
@@ -256,7 +255,6 @@ class DiaryWriteApiTest extends ApiBaseTest {
     void 마지막_순서_그룹원이_일기_작성_성공시_조회가능한_마지막_일기_날짜_업데이트_확인() throws JsonProcessingException {
         Group group = createGroup(2);
         updateSelf(group, 2);
-        member.updateLastViewableDiaryDate(LocalDate.now().minusMonths(1));
         Member nextMember = createMember(group, 1);
         Map<String, String> data = makeDiaryData();
 

--- a/src/test/java/com/exchangediary/diary/api/DiaryWriteApiTest.java
+++ b/src/test/java/com/exchangediary/diary/api/DiaryWriteApiTest.java
@@ -252,6 +252,29 @@ class DiaryWriteApiTest extends ApiBaseTest {
         assertThat(nextWriter.getLastViewableDiaryDate()).isEqualTo(LocalDate.now());
     }
 
+    @Test
+    void 마지막_순서_그룹원이_일기_작성_성공시_조회가능한_마지막_일기_날짜_업데이트_확인() throws JsonProcessingException {
+        Group group = createGroup(2);
+        updateSelf(group, 2);
+        member.updateLastViewableDiaryDate(LocalDate.now().minusMonths(1));
+        Member nextMember = createMember(group, 1);
+        Map<String, String> data = makeDiaryData();
+
+        RestAssured
+                .given().log().all()
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                .multiPart("data", objectMapper.writeValueAsString(data), "application/json")
+                .cookie("token", token)
+                .when().post(String.format(API_PATH, group.getId()))
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        Member writer = memberRepository.findById(this.member.getId()).get();
+        Member nextWriter = memberRepository.findById(nextMember.getId()).get();
+        assertThat(writer.getLastViewableDiaryDate()).isEqualTo(LocalDate.now());
+        assertThat(nextWriter.getLastViewableDiaryDate()).isEqualTo(LocalDate.now());
+    }
+
     private Diary createDiary(Group group) {
         Diary diary = Diary.builder()
                 .content("하이하이")

--- a/src/test/java/com/exchangediary/group/api/GroupCreateApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupCreateApiTest.java
@@ -46,6 +46,7 @@ public class GroupCreateApiTest extends ApiBaseTest {
         assertThat(groupCreator.getNickname()).isEqualTo(nickname);
         assertThat(groupCreator.getProfileImage()).isEqualTo(profileImage);
         assertThat(groupCreator.getGroupRole()).isEqualTo(GroupRole.GROUP_LEADER);
+        assertThat(groupCreator.getLastViewableDiaryDate()).isEqualTo(group.getCreatedAt().toLocalDate().minusDays(1));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/exchangediary/group/api/GroupJoinApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupJoinApiTest.java
@@ -46,6 +46,7 @@ class GroupJoinApiTest extends ApiBaseTest {
         assertThat(updatedMember.getOrderInGroup()).isEqualTo(2);
         assertThat(updatedMember.getGroup().getId()).isEqualTo(group.getId());
         assertThat(updatedMember.getGroupRole()).isEqualTo(GroupRole.GROUP_MEMBER);
+        assertThat(updatedMember.getLastViewableDiaryDate()).isEqualTo(group.getCreatedAt().toLocalDate().minusDays(1));
     }
 
     @Test

--- a/src/test/java/com/exchangediary/group/api/GroupLeaveApiTest.java
+++ b/src/test/java/com/exchangediary/group/api/GroupLeaveApiTest.java
@@ -48,12 +48,20 @@ public class GroupLeaveApiTest extends ApiBaseTest {
                 .statusCode(HttpStatus.OK.value());
 
         Member updatedMember = memberRepository.findById(member.getId()).get();
-        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedMember.getGroup()).isEqualTo(null);
         assertThat(updatedMember.getNickname()).isEqualTo(null);
         assertThat(updatedMember.getGroupRole()).isEqualTo(null);
         assertThat(updatedMember.getProfileImage()).isEqualTo(null);
         assertThat(updatedMember.getOrderInGroup()).isEqualTo(0);
+
+        Member updatedGroupMember = memberRepository.findById(groupMember.getId()).get();
+        assertThat(updatedGroupMember.getOrderInGroup()).isEqualTo(1);
+        assertThat(updatedGroupMember.getLastViewableDiaryDate()).isEqualTo(groupMember.getLastViewableDiaryDate());
+        Member updatedGroupMember2 = memberRepository.findById(groupMember2.getId()).get();
+        assertThat(updatedGroupMember2.getOrderInGroup()).isEqualTo(2);
+        assertThat(updatedGroupMember2.getLastViewableDiaryDate()).isEqualTo(groupMember2.getLastViewableDiaryDate());
+
+        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedGroup.getCurrentOrder()).isEqualTo(group.getCurrentOrder());
     }
 
@@ -77,12 +85,20 @@ public class GroupLeaveApiTest extends ApiBaseTest {
                 .statusCode(HttpStatus.OK.value());
 
         Member updatedMember = memberRepository.findById(member.getId()).get();
-        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedMember.getGroup()).isEqualTo(null);
         assertThat(updatedMember.getNickname()).isEqualTo(null);
         assertThat(updatedMember.getGroupRole()).isEqualTo(null);
         assertThat(updatedMember.getProfileImage()).isEqualTo(null);
         assertThat(updatedMember.getOrderInGroup()).isEqualTo(0);
+
+        Member updatedGroupMember = memberRepository.findById(groupMember.getId()).get();
+        assertThat(updatedGroupMember.getOrderInGroup()).isEqualTo(1);
+        assertThat(updatedGroupMember.getLastViewableDiaryDate()).isEqualTo(LocalDate.now());
+        Member updatedGroupMember2 = memberRepository.findById(groupMember2.getId()).get();
+        assertThat(updatedGroupMember2.getOrderInGroup()).isEqualTo(2);
+        assertThat(updatedGroupMember2.getLastViewableDiaryDate()).isEqualTo(groupMember2.getLastViewableDiaryDate());
+
+        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedGroup.getCurrentOrder()).isEqualTo(1);
     }
 
@@ -106,16 +122,20 @@ public class GroupLeaveApiTest extends ApiBaseTest {
                 .statusCode(HttpStatus.OK.value());
 
         Member updatedMember = memberRepository.findById(member.getId()).get();
-        Member updatedGroupMember = memberRepository.findById(groupMember.getId()).get();
-        Member updatedGroupMember2 = memberRepository.findById(groupMember2.getId()).get();
-        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedMember.getGroup()).isEqualTo(null);
         assertThat(updatedMember.getNickname()).isEqualTo(null);
         assertThat(updatedMember.getGroupRole()).isEqualTo(null);
         assertThat(updatedMember.getProfileImage()).isEqualTo(null);
         assertThat(updatedMember.getOrderInGroup()).isEqualTo(0);
+
+        Member updatedGroupMember = memberRepository.findById(groupMember.getId()).get();
         assertThat(updatedGroupMember.getOrderInGroup()).isEqualTo(1);
+        assertThat(updatedGroupMember.getLastViewableDiaryDate()).isEqualTo(groupMember.getLastViewableDiaryDate());
+        Member updatedGroupMember2 = memberRepository.findById(groupMember2.getId()).get();
         assertThat(updatedGroupMember2.getOrderInGroup()).isEqualTo(2);
+        assertThat(updatedGroupMember2.getLastViewableDiaryDate()).isEqualTo(groupMember2.getLastViewableDiaryDate());
+
+        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedGroup.getCurrentOrder()).isEqualTo(group.getCurrentOrder());
     }
 
@@ -139,16 +159,20 @@ public class GroupLeaveApiTest extends ApiBaseTest {
                 .statusCode(HttpStatus.OK.value());
 
         Member updatedMember = memberRepository.findById(member.getId()).get();
-        Member updatedGroupMember = memberRepository.findById(groupMember.getId()).get();
-        Member updatedGroupMember2 = memberRepository.findById(groupMember2.getId()).get();
-        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedMember.getGroup()).isEqualTo(null);
         assertThat(updatedMember.getNickname()).isEqualTo(null);
         assertThat(updatedMember.getGroupRole()).isEqualTo(null);
         assertThat(updatedMember.getProfileImage()).isEqualTo(null);
         assertThat(updatedMember.getOrderInGroup()).isEqualTo(0);
+
+        Member updatedGroupMember = memberRepository.findById(groupMember.getId()).get();
         assertThat(updatedGroupMember.getOrderInGroup()).isEqualTo(1);
+        assertThat(updatedGroupMember.getLastViewableDiaryDate()).isEqualTo(groupMember.getLastViewableDiaryDate());
+        Member updatedGroupMember2 = memberRepository.findById(groupMember2.getId()).get();
         assertThat(updatedGroupMember2.getOrderInGroup()).isEqualTo(2);
+        assertThat(updatedGroupMember2.getLastViewableDiaryDate()).isEqualTo(groupMember2.getLastViewableDiaryDate());
+
+        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedGroup.getCurrentOrder()).isEqualTo(2);
     }
 
@@ -172,16 +196,21 @@ public class GroupLeaveApiTest extends ApiBaseTest {
                 .statusCode(HttpStatus.OK.value());
 
         Member updatedMember = memberRepository.findById(member.getId()).get();
-        Member updatedGroupMember = memberRepository.findById(groupMember.getId()).get();
-        Member updatedGroupMember2 = memberRepository.findById(groupMember2.getId()).get();
-        Group updatedGroup = groupRepository.findById(group.getId()).get();
+
         assertThat(updatedMember.getGroup()).isEqualTo(null);
         assertThat(updatedMember.getNickname()).isEqualTo(null);
         assertThat(updatedMember.getGroupRole()).isEqualTo(null);
         assertThat(updatedMember.getProfileImage()).isEqualTo(null);
         assertThat(updatedMember.getOrderInGroup()).isEqualTo(0);
+
+        Member updatedGroupMember = memberRepository.findById(groupMember.getId()).get();
         assertThat(updatedGroupMember.getOrderInGroup()).isEqualTo(1);
+        assertThat(updatedGroupMember.getLastViewableDiaryDate()).isEqualTo(groupMember.getLastViewableDiaryDate());
+        Member updatedGroupMember2 = memberRepository.findById(groupMember2.getId()).get();
         assertThat(updatedGroupMember2.getOrderInGroup()).isEqualTo(2);
+        assertThat(updatedGroupMember2.getLastViewableDiaryDate()).isEqualTo(LocalDate.now());
+
+        Group updatedGroup = groupRepository.findById(group.getId()).get();
         assertThat(updatedGroup.getCurrentOrder()).isEqualTo(2);
     }
 
@@ -204,6 +233,7 @@ public class GroupLeaveApiTest extends ApiBaseTest {
     }
 
     @Test
+    @DisplayName("그룹에 방장만 남은 경우, 방장 나가기 가능. 그리고 그룹 삭제됨")
     public void 그룹_나가기_마지막_사람_방장_나갈수있음() {
         Group group = createGroup(1);
         groupRepository.save(group);
@@ -239,6 +269,7 @@ public class GroupLeaveApiTest extends ApiBaseTest {
                 .kakaoId(12345L)
                 .orderInGroup(orderInGroup)
                 .profileImage("red")
+                .lastViewableDiaryDate(LocalDate.now().minusDays(1))
                 .group(group)
                 .build();
     }


### PR DESCRIPTION
## Work Description
> 그룹 탈퇴 시, 조회 가능한 마지막 일기 날짜 업데이트 오류 해결

- 그룹 탈퇴/강퇴 시, 현재 순서가 다른 그룹원으로 바뀔 경우, lastViewableDiaryDate를 업데이트했습니다.
- 조회 가능한 마지막 일기 날짜 업데이트 검증이 필요한 부분에 테스트를 추가했습니다.

## ISSUE
- closed #345


## Screenshot
#### 모든 테스트 결과
<img width="222" alt="Screenshot 2024-10-30 at 9 33 48 PM" src="https://github.com/user-attachments/assets/572dcb27-19cb-4f68-85ea-7b94d3f290f4">
