### PR TITLE
방장 권한 및 탈퇴 알림 구현

### DIFF
--- a/src/main/java/com/exchangediary/diary/ui/ApiDiaryController.java
+++ b/src/main/java/com/exchangediary/diary/ui/ApiDiaryController.java
@@ -37,7 +37,7 @@ public class ApiDiaryController {
             @RequestAttribute Long memberId
     ) {
         Long diaryId = diaryWriteService.writeDiary(diaryRequest, file, groupId, memberId);
-        notificationService.pushToAllGroupMembersExceptSelf(groupId, memberId, "친구가 일기를 작성했어요!");
+        notificationService.pushToAllGroupMembersExceptMember(groupId, memberId, "친구가 일기를 작성했어요!");
         notificationService.pushDiaryOrderNotification(groupId);
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/com/exchangediary/global/exception/ErrorCode.java
+++ b/src/main/java/com/exchangediary/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹을 찾을 수 없습니다."),
     GROUP_LEADER_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹장을 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."),
+    FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "member id와 매핑된 fcm 토큰을 찾을 수 없습니다."),
 
     FULL_MEMBERS_OF_GROUP(HttpStatus.CONFLICT, "그룹원이 꽉 차\n해당 그룹에 들어갈 수 없습니다."),
     ALREADY_SKIP_ORDER_TODAY(HttpStatus.CONFLICT, "이미 한 번 건너뛰었어요!\n내일 다시 건너뛸 수 있어요."),

--- a/src/main/java/com/exchangediary/global/exception/ErrorCode.java
+++ b/src/main/java/com/exchangediary/global/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     FAILED_TO_GET_KAKAO_USER_INFO(HttpStatus.INTERNAL_SERVER_ERROR, "kakao 사용자 정보 조회에 실패했습니다."),
     FAILED_TO_ISSUE_FIREBASE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "firebase 토큰 발급에 실패했습니다."),
     FAILED_TO_SEND_MESSAGE(HttpStatus.INTERNAL_SERVER_ERROR, "메시지 전송에 실패했습니다."),
+    NEED_TO_AT_LEAST_ONE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "하나 이상의 fcm 토큰이 필요합니다."),
     FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 오류가 발생했습니다.");
 
     private final HttpStatus statusCode;

--- a/src/main/java/com/exchangediary/global/exception/RequestValidationExceptionHandler.java
+++ b/src/main/java/com/exchangediary/global/exception/RequestValidationExceptionHandler.java
@@ -47,4 +47,15 @@ public class RequestValidationExceptionHandler {
                 .value((String) exception.getValue())
                 .build();
     }
+
+    @ExceptionHandler(NumberFormatException.class)
+    @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+    public ApiErrorResponse handleInvalidNumberFormatException(NumberFormatException exception) {
+        log.error("{}", String.format("%s", exception.getMessage()));
+        return ApiErrorResponse.builder()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .message(exception.getMessage())
+                .value(exception.getLocalizedMessage())
+                .build();
+    }
 }

--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -31,13 +31,16 @@ public class GroupLeaderService {
         newLeader.changeGroupRole(GroupRole.GROUP_LEADER);
     }
 
-    public void skipDiaryOrder(Long groupId) {
+    public int skipDiaryOrder(Long groupId) {
         Group group = groupQueryService.findGroup(groupId);
         groupValidationService.checkSkipOrderAuthority(group);
-        group.updateCurrentOrder(group.getCurrentOrder() + 1, group.getMembers().size());
+
+        int groupOrder = group.getCurrentOrder();
+        group.updateCurrentOrder(groupOrder + 1, group.getMembers().size());
         group.updateLastSkipOrderDate();
         Member currentWriter = groupMemberService.findCurrentOrderMember(group);
         currentWriter.updateLastViewableDiaryDate();
+        return groupOrder;
     }
 
     public void kickOutMember(Long groupId, GroupKickOutRequest request) {

--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -43,10 +43,11 @@ public class GroupLeaderService {
         return groupOrder;
     }
 
-    public void kickOutMember(Long groupId, GroupKickOutRequest request) {
+    public long kickOutMember(Long groupId, GroupKickOutRequest request) {
         Group group = groupQueryService.findGroup(groupId);
         Member kickMember = groupMemberService.findMemberByNickname(group, request.nickname());
         groupLeaveService.leaveGroup(groupId, kickMember.getId());
+        return kickMember.getId();
     }
 
     public boolean isGroupLeader(Long memberId) {

--- a/src/main/java/com/exchangediary/group/service/GroupQueryService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupQueryService.java
@@ -49,7 +49,7 @@ public class GroupQueryService {
         return GroupMonthlyResponse.of(group);
     }
 
-    public GroupMembersResponse listGroupMembersByOrder(Long memberId, Long groupId) {
+    public GroupMembersResponse listGroupMembersInformation(Long memberId, Long groupId) {
         Group group = findGroup(groupId);
         Member self = groupMemberService.findSelfInGroup(group, memberId);
         Member leader = groupMemberService.findGroupLeader(group);

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
@@ -98,11 +98,11 @@ public class ApiGroupController {
     }
 
     @GetMapping("/{groupId}/members")
-    public ResponseEntity<GroupMembersResponse> findGroupMembersBySelfOrder(
+    public ResponseEntity<GroupMembersResponse> listGroupMembersInformation(
             @PathVariable Long groupId,
             @RequestAttribute Long memberId
     ) {
-        GroupMembersResponse response = groupQueryService.listGroupMembersByOrder(memberId, groupId);
+        GroupMembersResponse response = groupQueryService.listGroupMembersInformation(memberId, groupId);
         return ResponseEntity
                 .ok()
                 .body(response);

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
@@ -114,6 +114,7 @@ public class ApiGroupController {
             @RequestAttribute Long memberId
     ) {
         groupLeaveService.leaveGroup(groupId, memberId);
+        notificationService.pushToAllGroupMembersExceptMember(groupId, memberId, "친구가 그룹에서 나갔어요!");
         return ResponseEntity
                 .ok()
                 .build();

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
@@ -27,7 +27,7 @@ public class ApiGroupLeaderController {
             @RequestBody GroupLeaderHandOverRequest request
     ) {
         groupLeaderService.handOverGroupLeader(groupId, memberId, request);
-        notificationService.pushToAllGroupMembersExceptSelf(groupId, memberId, "방장이 다른 친구에게 방장 역할을 넘겨줬어요!");
+        notificationService.pushToAllGroupMembersExceptMember(groupId, memberId, "방장이 다른 친구에게 방장 역할을 넘겨줬어요!");
         return ResponseEntity
                 .ok()
                 .build();
@@ -48,7 +48,9 @@ public class ApiGroupLeaderController {
             @PathVariable Long groupId,
             @RequestBody GroupKickOutRequest request
     ) {
-        groupLeaderService.kickOutMember(groupId, request);
+        long memberId = groupLeaderService.kickOutMember(groupId, request);
+        notificationService.pushToAllGroupMembersExceptMember(groupId, memberId, "친구가 그룹에서 나갔어요!");
+        notificationService.pushNotification(memberId, "앗, 그룹에서 내보내졌어요.\n다른 스프링에서 일기 쓰기를 시작해요!");
         return ResponseEntity
                 .ok()
                 .build();

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
@@ -35,7 +35,8 @@ public class ApiGroupLeaderController {
 
     @PatchMapping("/skip-order")
     public ResponseEntity<Void> skipDiaryOrder(@PathVariable Long groupId) {
-        groupLeaderService.skipDiaryOrder(groupId);
+        int previousOrder = groupLeaderService.skipDiaryOrder(groupId);
+        notificationService.pushSkipOverDiaryNotification(groupId, previousOrder);
         notificationService.pushDiaryOrderNotification(groupId);
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
@@ -27,6 +27,7 @@ public class ApiGroupLeaderController {
             @RequestBody GroupLeaderHandOverRequest request
     ) {
         groupLeaderService.handOverGroupLeader(groupId, memberId, request);
+        notificationService.pushToAllGroupMembersExceptSelf(groupId, memberId, "방장이 다른 친구에게 방장 역할을 넘겨줬어요!");
         return ResponseEntity
                 .ok()
                 .build();
@@ -40,6 +41,7 @@ public class ApiGroupLeaderController {
                 .ok()
                 .build();
     }
+
     @PatchMapping("/leave")
     public ResponseEntity<Void> kickOutMember(
             @PathVariable Long groupId,

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -15,6 +15,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<String> findAllTokenByGroupIdExceptMemberId(Long groupId, Long memberId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.orderInGroup = m.group.currentOrder")
     String findCurrentOrderMemberByGroupId(Long groupId);
+    @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.orderInGroup = :order")
+    String findByGroupIdAndOrder(Long groupId, int order);
     @Query("SELECT n.token FROM Notification n " +
             "JOIN n.member m " +
             "JOIN m.group g " +

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -14,7 +14,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.id != :memberId")
     List<String> findAllTokenByGroupIdExceptMemberId(Long groupId, Long memberId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.orderInGroup = m.group.currentOrder")
-    String findCurrentOrderMemberByGroupId(Long groupId);
+    String findByGroupIdAndCurrentOrder(Long groupId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.orderInGroup = :order")
     String findByGroupIdAndOrder(Long groupId, int order);
     @Query("SELECT n.token FROM Notification n " +

--- a/src/main/java/com/exchangediary/notification/service/MessageSendService.java
+++ b/src/main/java/com/exchangediary/notification/service/MessageSendService.java
@@ -18,6 +18,10 @@ public class MessageSendService {
     private static final String TITLE = "스프링";
 
     public void sendMessage(String token, String body) {
+        if (token == null) {
+            throw new MessagingFailureException(ErrorCode.NEED_TO_AT_LEAST_ONE_TOKEN, "fcm 토큰이 null입니다.", null);
+        }
+
         Notification notification = Notification.builder()
                 .setTitle(TITLE)
                 .setBody(body)
@@ -36,6 +40,10 @@ public class MessageSendService {
     }
 
     public void sendMulticastMessage(List<String> tokens, String body) {
+        if (tokens.isEmpty()) {
+            throw new MessagingFailureException(ErrorCode.NEED_TO_AT_LEAST_ONE_TOKEN, "", null);
+        }
+
         Notification notification = Notification.builder()
                 .setTitle(TITLE)
                 .setBody(body)

--- a/src/main/java/com/exchangediary/notification/service/NotificationService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationService.java
@@ -11,13 +11,18 @@ public class NotificationService {
     private final MessageSendService messageSendService;
     private final NotificationTokenService notificationTokenService;
 
+    public void pushNotification(Long memberId, String body) {
+        String token = notificationTokenService.findTokenByMemberId(memberId);
+        messageSendService.sendMessage(token, body);
+    }
+
     public void pushToAllGroupMembers(Long groupId, String body) {
         List<String> tokens = notificationTokenService.findTokensByGroup(groupId);
         messageSendService.sendMulticastMessage(tokens, body);
     }
 
-    public void pushToAllGroupMembersExceptSelf(Long groupId, Long memberId, String body) {
-        List<String> tokens = notificationTokenService.findTokensByGroupExceptSelf(groupId, memberId);
+    public void pushToAllGroupMembersExceptMember(Long groupId, Long memberId, String body) {
+        List<String> tokens = notificationTokenService.findTokensByGroupExceptMember(groupId, memberId);
         messageSendService.sendMulticastMessage(tokens, body);
     }
 

--- a/src/main/java/com/exchangediary/notification/service/NotificationService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationService.java
@@ -26,6 +26,11 @@ public class NotificationService {
         messageSendService.sendMessage(token, "일기 작성 차례가 되었어요!");
     }
 
+    public void pushSkipOverDiaryNotification(Long groupId, int previousOrder) {
+        String token = notificationTokenService.findTokenByPreviousOrder(groupId, previousOrder);
+        messageSendService.sendMessage(token, "방장이 일기 순서를 건너뛰었어요.\n다음 순서를 기다려주세요!");
+    }
+
     public void pushWriteDiaryNotification() {
         List<String> tokens = notificationTokenService.findTokensByCurrentOrderInAllGroup();
         messageSendService.sendMulticastMessage(tokens, "기다리는 친구들을 위해 일기를 작성해주세요!");

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -37,7 +37,7 @@ public class NotificationTokenService {
     @Transactional(readOnly = true)
     public String findTokenByMemberId(Long memberId) {
         return notificationRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND, "", String.valueOf(memberId)))
+                .orElseThrow(() -> new NotFoundException(ErrorCode.FCM_TOKEN_NOT_FOUND, "", String.valueOf(memberId)))
                 .getToken();
     }
 

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -33,6 +33,11 @@ public class NotificationTokenService {
     }
 
     @Transactional(readOnly = true)
+    public String findTokenByPreviousOrder(Long groupId, int previousOrder) {
+        return notificationRepository.findByGroupIdAndOrder(groupId, previousOrder);
+    }
+
+    @Transactional(readOnly = true)
     public List<String> findTokensByCurrentOrderInAllGroup() {
         return notificationRepository.findAllTokenNoDiaryToday();
     }

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -29,7 +29,7 @@ public class NotificationTokenService {
 
     @Transactional(readOnly = true)
     public String findTokenByCurrentOrder(Long groupId) {
-        return notificationRepository.findCurrentOrderMemberByGroupId(groupId);
+        return notificationRepository.findByGroupIdAndCurrentOrder(groupId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -1,5 +1,7 @@
 package com.exchangediary.notification.service;
 
+import com.exchangediary.global.exception.ErrorCode;
+import com.exchangediary.global.exception.serviceexception.NotFoundException;
 import com.exchangediary.member.domain.entity.Member;
 import com.exchangediary.member.service.MemberQueryService;
 import com.exchangediary.notification.domain.NotificationRepository;
@@ -23,8 +25,20 @@ public class NotificationTokenService {
     }
 
     @Transactional(readOnly = true)
-    public List<String> findTokensByGroupExceptSelf(Long groupId, Long memberId) {
+    public List<String> findTokensByGroupExceptMember(Long groupId, Long memberId) {
         return notificationRepository.findAllTokenByGroupIdExceptMemberId(groupId, memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> findTokensByCurrentOrderInAllGroup() {
+        return notificationRepository.findAllTokenNoDiaryToday();
+    }
+
+    @Transactional(readOnly = true)
+    public String findTokenByMemberId(Long memberId) {
+        return notificationRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND, "", String.valueOf(memberId)))
+                .getToken();
     }
 
     @Transactional(readOnly = true)
@@ -35,11 +49,6 @@ public class NotificationTokenService {
     @Transactional(readOnly = true)
     public String findTokenByPreviousOrder(Long groupId, int previousOrder) {
         return notificationRepository.findByGroupIdAndOrder(groupId, previousOrder);
-    }
-
-    @Transactional(readOnly = true)
-    public List<String> findTokensByCurrentOrderInAllGroup() {
-        return notificationRepository.findAllTokenNoDiaryToday();
     }
 
     @Transactional

--- a/src/test/java/com/exchangediary/ApiBaseTest.java
+++ b/src/test/java/com/exchangediary/ApiBaseTest.java
@@ -3,7 +3,7 @@ package com.exchangediary;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.domain.entity.Member;
 import com.exchangediary.member.service.JwtService;
-import com.exchangediary.notification.service.MessageSendService;
+import com.exchangediary.notification.service.NotificationService;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +24,7 @@ public class ApiBaseTest {
     @Autowired
     private JwtService jwtService;
     @MockBean
-    private MessageSendService messageSendService;
+    private NotificationService notificationService;
 
     protected Member member;
     protected String token;

--- a/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
@@ -57,7 +57,7 @@ public class NotificationRepositoryUnitTest {
     }
 
     @Test
-    @DisplayName("findCurrentOrderMemberByGroupId 동작 확인")
+    @DisplayName("findByGroupIdAndCurrentOrder 동작 확인")
     void 현재_순서_그룹원_토큰_가져오기() {
         Group group = Group.of("버니즈", "code");
         entityManager.persist(group);
@@ -67,7 +67,7 @@ public class NotificationRepositoryUnitTest {
         createMember(4, group);
         entityManager.flush();
 
-        String token = notificationRepository.findCurrentOrderMemberByGroupId(group.getId());
+        String token = notificationRepository.findByGroupIdAndCurrentOrder(group.getId());
 
         assertThat(token).isEqualTo("버니즈1");
     }

--- a/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
@@ -73,6 +73,20 @@ public class NotificationRepositoryUnitTest {
     }
 
     @Test
+    @DisplayName("findByGroupIdAndOrder 동작 확인")
+    void 일기순서_건너뛰어진_그룹원_토큰_가져오기() {
+        Group group = Group.of("버니즈", "code");
+        entityManager.persist(group);
+        createMember(1, group);
+        createMember(2, group);
+        entityManager.flush();
+
+        String token = notificationRepository.findByGroupIdAndOrder(group.getId(), 2);
+
+        assertThat(token).isEqualTo("버니즈2");
+    }
+
+    @Test
     @DisplayName("findAllTokenNoDiaryToday 동작 확인")
     void 오늘_일기_작성하지않은_모든_그룹원_토큰_가져오기() {
         Group group1 = Group.of("그룹1", "code1");


### PR DESCRIPTION
## Work Description
> 방장 권한 및 탈퇴 알림 구현

- 방장 권한 위임
  - 방장 제외한 모두에게 알림
- 일기 건너뛰기
  - 건너뛰기 당한 사람에게 알림
  - 업데이트된 현재 작성자에게 알림 (#374 구현됨) 
- 강퇴
  - 강퇴당한 사람 제외 모두에게 알림
  - 강퇴당한 사람에게 알림 
- 탈퇴
  - 탈퇴한 사람 제외 모두에게 알림 

## ISSUE
- closed #370
- closed #372

## Screenshot
<img width="454" alt="Screenshot 2024-11-09 at 11 07 06 PM" src="https://github.com/user-attachments/assets/0d1cf797-40d2-4cd0-bdd4-8bb96bb0276c">

## To Reviewers
- 알림 목록에 있는대로 구현했는데 질문이 있어 남깁니다. 답변 부탁드려요! @seungaeahn 
1. 방장 권한 위임 시, 방장에게도 동일한 메시지의 알림 보내는 것인지?
2. 강퇴 권한 실행 시, 방장에게도 알림이 가는 것인지?

