### PR TITLE
사용자 - 알림 연관관계 변경 및 fcm 토큰 신선도 관리

### DIFF
--- a/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaderService.java
@@ -32,16 +32,16 @@ public class GroupLeaderService {
         return newLeader.getId();
     }
 
-    public int skipDiaryOrder(String groupId) {
+    public long skipDiaryOrder(String groupId) {
         Group group = groupQueryService.findGroup(groupId);
         groupValidationService.checkSkipOrderAuthority(group);
 
-        int groupOrder = group.getCurrentOrder();
-        group.updateCurrentOrder(groupOrder + 1, group.getMembers().size());
+        long skipDiaryMemberId = groupMemberService.findCurrentOrderMember(group).getId();
+        group.updateCurrentOrder(group.getCurrentOrder() + 1, group.getMembers().size());
         group.updateLastSkipOrderDate();
         Member currentWriter = groupMemberService.findCurrentOrderMember(group);
         currentWriter.updateLastViewableDiaryDate();
-        return groupOrder;
+        return skipDiaryMemberId;
     }
 
     public long kickOutMember(String groupId, GroupKickOutRequest request) {

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
@@ -89,7 +89,7 @@ public class ApiGroupController {
             @RequestAttribute Long memberId
     ) {
         groupJoinService.joinGroup(groupId, request, memberId);
-        notificationService.pushToAllGroupMembers(groupId, "새로운 친구가 들어왔어요!");
+        notificationService.pushToAllGroupMembersExceptMember(groupId, memberId, "새로운 친구가 들어왔어요!");
         return ResponseEntity
                 .ok()
                 .build();

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
@@ -36,8 +36,8 @@ public class ApiGroupLeaderController {
 
     @PatchMapping("/skip-order")
     public ResponseEntity<Void> skipDiaryOrder(@PathVariable String groupId) {
-        int previousOrder = groupLeaderService.skipDiaryOrder(groupId);
-        notificationService.pushSkipOverDiaryNotification(groupId, previousOrder);
+        long skipDiaryMemberId = groupLeaderService.skipDiaryOrder(groupId);
+        notificationService.pushNotification(skipDiaryMemberId, "방장이 일기 순서를 건너뛰었어요.\n다음 순서를 기다려주세요!");
         notificationService.pushDiaryOrderNotification(groupId);
         return ResponseEntity
                 .ok()
@@ -49,9 +49,9 @@ public class ApiGroupLeaderController {
             @PathVariable String groupId,
             @RequestBody GroupKickOutRequest request
     ) {
-        long memberId = groupLeaderService.kickOutMember(groupId, request);
-        notificationService.pushToAllGroupMembersExceptMemberAndLeader(groupId, memberId, "방장이 친구를 그룹에서 내보냈어요!");
-        notificationService.pushNotification(memberId, "앗, 그룹에서 내보내졌어요.\n다른 스프링에서 일기 쓰기를 시작해요!");
+        long kickOutMemberId = groupLeaderService.kickOutMember(groupId, request);
+        notificationService.pushToAllGroupMembersExceptMemberAndLeader(groupId, kickOutMemberId, "방장이 친구를 그룹에서 내보냈어요!");
+        notificationService.pushNotification(kickOutMemberId, "앗, 그룹에서 내보내졌어요.\n다른 스프링에서 일기 쓰기를 시작해요!");
         return ResponseEntity
                 .ok()
                 .build();

--- a/src/main/java/com/exchangediary/notification/component/FCMControllerAdvice.java
+++ b/src/main/java/com/exchangediary/notification/component/FCMControllerAdvice.java
@@ -1,4 +1,4 @@
-package com.exchangediary.notification.config;
+package com.exchangediary.notification.component;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;

--- a/src/main/java/com/exchangediary/notification/component/FCMInitializer.java
+++ b/src/main/java/com/exchangediary/notification/component/FCMInitializer.java
@@ -1,4 +1,4 @@
-package com.exchangediary.notification.config;
+package com.exchangediary.notification.component;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;

--- a/src/main/java/com/exchangediary/notification/component/NotificationScheduler.java
+++ b/src/main/java/com/exchangediary/notification/component/NotificationScheduler.java
@@ -1,4 +1,4 @@
-package com.exchangediary.notification.config;
+package com.exchangediary.notification.component;
 
 import com.exchangediary.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/exchangediary/notification/component/NotificationScheduler.java
+++ b/src/main/java/com/exchangediary/notification/component/NotificationScheduler.java
@@ -1,6 +1,7 @@
 package com.exchangediary.notification.component;
 
 import com.exchangediary.notification.service.NotificationService;
+import com.exchangediary.notification.service.NotificationTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -9,9 +10,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class NotificationScheduler {
     private final NotificationService notificationService;
+    private final NotificationTokenService notificationTokenService;
 
     @Scheduled(cron = "0 0 9,21 * * *")
     public void pushWriteDiaryNotification() {
         notificationService.pushWriteDiaryNotification();
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void manageTokenFreshness() {
+        notificationTokenService.deleteOldTokens();
     }
 }

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByMemberId(Long memberId);
-    @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId")
-    List<String> findTokensByGroupId(String groupId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.id != :memberId")
     List<String> findTokensByGroupIdExceptMemberId(String groupId, Long memberId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.id != :memberId AND m.groupRole != 'GROUP_LEADER'")

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByMemberId(Long memberId);
@@ -17,8 +16,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<String> findTokensByGroupIdExceptMemberIdAndLeader(String groupId, Long memberId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.orderInGroup = m.group.currentOrder")
     List<String> findByGroupIdAndCurrentOrder(String groupId);
-    @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.orderInGroup = :order")
-    List<String> findByGroupIdAndOrder(String groupId, int order);
     @Query("SELECT n.token FROM Notification n " +
             "JOIN n.member m " +
             "JOIN m.group g " +

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -8,21 +8,21 @@ import java.util.List;
 import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    Optional<Notification> findByMemberId(Long memberId);
+    List<Notification> findByMemberId(Long memberId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId")
-    List<String> findAllTokenByGroupId(String groupId);
+    List<String> findTokensByGroupId(String groupId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.id != :memberId")
-    List<String> findAllTokenByGroupIdExceptMemberId(String groupId, Long memberId);
+    List<String> findTokensByGroupIdExceptMemberId(String groupId, Long memberId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.id != :memberId AND m.groupRole != 'GROUP_LEADER'")
-    List<String> findAllTokenByGroupIdExceptMemberIdAndLeader(String groupId, Long memberId);
+    List<String> findTokensByGroupIdExceptMemberIdAndLeader(String groupId, Long memberId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.orderInGroup = m.group.currentOrder")
-    String findByGroupIdAndCurrentOrder(String groupId);
+    List<String> findByGroupIdAndCurrentOrder(String groupId);
     @Query("SELECT n.token FROM Notification n JOIN n.member m WHERE m.group.id = :groupId AND m.orderInGroup = :order")
-    String findByGroupIdAndOrder(String groupId, int order);
+    List<String> findByGroupIdAndOrder(String groupId, int order);
     @Query("SELECT n.token FROM Notification n " +
             "JOIN n.member m " +
             "JOIN m.group g " +
             "LEFT JOIN Diary d ON d.group = g AND CAST(d.createdAt AS DATE) = CURRENT_DATE " +
             "WHERE m.orderInGroup = m.group.currentOrder AND d.id is NULL")
-    List<String> findAllTokenNoDiaryToday();
+    List<String> findTokensNoDiaryToday();
 }

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.exchangediary.notification.domain;
 
 import com.exchangediary.notification.domain.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -20,4 +21,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             "LEFT JOIN Diary d ON d.group = g AND CAST(d.createdAt AS DATE) = CURRENT_DATE " +
             "WHERE m.orderInGroup = m.group.currentOrder AND d.id is NULL")
     List<String> findTokensNoDiaryToday();
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE CURRENT_DATE - CAST(n.createdAt AS DATE) >= 30")
+    void deleteAllIfAMonthOld();
 }

--- a/src/main/java/com/exchangediary/notification/domain/entity/Notification.java
+++ b/src/main/java/com/exchangediary/notification/domain/entity/Notification.java
@@ -9,7 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,7 +31,7 @@ public class Notification extends BaseEntity {
     @NotNull
     private String token;
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "notification_member_id_fkey"))
     private Member member;
 

--- a/src/main/java/com/exchangediary/notification/service/MessageSendService.java
+++ b/src/main/java/com/exchangediary/notification/service/MessageSendService.java
@@ -4,7 +4,6 @@ import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.global.exception.serviceexception.MessagingFailureException;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
@@ -16,28 +15,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MessageSendService {
     private static final String TITLE = "스프링";
-
-    public void sendMessage(String token, String body) {
-        if (token == null) {
-            throw new MessagingFailureException(ErrorCode.NEED_TO_AT_LEAST_ONE_TOKEN, "fcm 토큰이 null입니다.", null);
-        }
-
-        Notification notification = Notification.builder()
-                .setTitle(TITLE)
-                .setBody(body)
-                .build();
-
-        Message message = Message.builder()
-                .setToken(token)
-                .setNotification(notification)
-                .build();
-
-        try {
-            FirebaseMessaging.getInstance().send(message);
-        } catch (FirebaseMessagingException e) {
-            throw new MessagingFailureException(ErrorCode.FAILED_TO_SEND_MESSAGE, "", token);
-        }
-    }
 
     public void sendMulticastMessage(List<String> tokens, String body) {
         if (tokens.isEmpty()) {

--- a/src/main/java/com/exchangediary/notification/service/NotificationService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationService.java
@@ -16,11 +16,6 @@ public class NotificationService {
         messageSendService.sendMulticastMessage(tokens, body);
     }
 
-    public void pushToAllGroupMembers(String groupId, String body) {
-        List<String> tokens = notificationTokenService.findTokensByGroup(groupId);
-        messageSendService.sendMulticastMessage(tokens, body);
-    }
-
     public void pushToAllGroupMembersExceptMember(String groupId, Long memberId, String body) {
         List<String> tokens = notificationTokenService.findTokensByGroupExceptMember(groupId, memberId);
         messageSendService.sendMulticastMessage(tokens, body);

--- a/src/main/java/com/exchangediary/notification/service/NotificationService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationService.java
@@ -12,8 +12,8 @@ public class NotificationService {
     private final NotificationTokenService notificationTokenService;
 
     public void pushNotification(Long memberId, String body) {
-        String token = notificationTokenService.findTokenByMemberId(memberId);
-        messageSendService.sendMessage(token, body);
+        List<String> tokens = notificationTokenService.findTokensByMemberId(memberId);
+        messageSendService.sendMulticastMessage(tokens, body);
     }
 
     public void pushToAllGroupMembers(String groupId, String body) {
@@ -32,13 +32,13 @@ public class NotificationService {
     }
 
     public void pushDiaryOrderNotification(String groupId) {
-        String token = notificationTokenService.findTokenByCurrentOrder(groupId);
-        messageSendService.sendMessage(token, "일기 작성 차례가 되었어요!");
+        List<String> tokens = notificationTokenService.findTokensByCurrentOrder(groupId);
+        messageSendService.sendMulticastMessage(tokens, "일기 작성 차례가 되었어요!");
     }
 
     public void pushSkipOverDiaryNotification(String groupId, int previousOrder) {
-        String token = notificationTokenService.findTokenByPreviousOrder(groupId, previousOrder);
-        messageSendService.sendMessage(token, "방장이 일기 순서를 건너뛰었어요.\n다음 순서를 기다려주세요!");
+        List<String> tokens = notificationTokenService.findTokensByPreviousOrder(groupId, previousOrder);
+        messageSendService.sendMulticastMessage(tokens, "방장이 일기 순서를 건너뛰었어요.\n다음 순서를 기다려주세요!");
     }
 
     public void pushWriteDiaryNotification() {

--- a/src/main/java/com/exchangediary/notification/service/NotificationService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationService.java
@@ -36,11 +36,6 @@ public class NotificationService {
         messageSendService.sendMulticastMessage(tokens, "일기 작성 차례가 되었어요!");
     }
 
-    public void pushSkipOverDiaryNotification(String groupId, int previousOrder) {
-        List<String> tokens = notificationTokenService.findTokensByPreviousOrder(groupId, previousOrder);
-        messageSendService.sendMulticastMessage(tokens, "방장이 일기 순서를 건너뛰었어요.\n다음 순서를 기다려주세요!");
-    }
-
     public void pushWriteDiaryNotification() {
         List<String> tokens = notificationTokenService.findTokensByCurrentOrderInAllGroup();
         messageSendService.sendMulticastMessage(tokens, "기다리는 친구들을 위해 일기를 작성해주세요!");

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -21,58 +21,53 @@ public class NotificationTokenService {
 
     @Transactional(readOnly = true)
     public List<String> findTokensByGroup(String groupId) {
-        return notificationRepository.findAllTokenByGroupId(groupId);
+        return notificationRepository.findTokensByGroupId(groupId);
     }
 
     @Transactional(readOnly = true)
     public List<String> findTokensByGroupExceptMember(String groupId, Long memberId) {
-        return notificationRepository.findAllTokenByGroupIdExceptMemberId(groupId, memberId);
+        return notificationRepository.findTokensByGroupIdExceptMemberId(groupId, memberId);
     }
 
     @Transactional(readOnly = true)
     public List<String> findTokensByGroupExceptMemberAndLeader(String groupId, Long memberId) {
-        return notificationRepository.findAllTokenByGroupIdExceptMemberIdAndLeader(groupId, memberId);
+        return notificationRepository.findTokensByGroupIdExceptMemberIdAndLeader(groupId, memberId);
     }
 
     @Transactional(readOnly = true)
     public List<String> findTokensByCurrentOrderInAllGroup() {
-        return notificationRepository.findAllTokenNoDiaryToday();
+        return notificationRepository.findTokensNoDiaryToday();
     }
 
     @Transactional(readOnly = true)
-    public String findTokenByMemberId(Long memberId) {
-        return notificationRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.FCM_TOKEN_NOT_FOUND, "", String.valueOf(memberId)))
-                .getToken();
+    public List<String> findTokensByMemberId(Long memberId) {
+        List<Notification> notifications = notificationRepository.findByMemberId(memberId);
+
+        if (notifications.isEmpty()) {
+            throw new NotFoundException(ErrorCode.FCM_TOKEN_NOT_FOUND, "", String.valueOf(memberId));
+        }
+        return notifications.stream()
+                .map(Notification::getToken)
+                .toList();
     }
 
     @Transactional(readOnly = true)
-    public String findTokenByCurrentOrder(String groupId) {
+    public List<String> findTokensByCurrentOrder(String groupId) {
         return notificationRepository.findByGroupIdAndCurrentOrder(groupId);
     }
 
     @Transactional(readOnly = true)
-    public String findTokenByPreviousOrder(String groupId, int previousOrder) {
+    public List<String> findTokensByPreviousOrder(String groupId, int previousOrder) {
         return notificationRepository.findByGroupIdAndOrder(groupId, previousOrder);
     }
 
     @Transactional
     public void saveNotificationToken(NotificationTokenRequest notificationTokenRequest, Long memberId) {
         Member member = memberQueryService.findMember(memberId);
-
-        notificationRepository.findByMemberId(memberId)
-                .ifPresentOrElse(
-                        notification -> {
-                            notification.updateToken(notificationTokenRequest.token());
-                            notificationRepository.save(notification);
-                        },
-                        () -> {
-                            Notification notification = Notification.builder()
-                                    .token(notificationTokenRequest.token())
-                                    .member(member)
-                                    .build();
-                            notificationRepository.save(notification);
-                        }
-                );
+        Notification notification = Notification.builder()
+                .token(notificationTokenRequest.token())
+                .member(member)
+                .build();
+        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -56,11 +56,6 @@ public class NotificationTokenService {
         return notificationRepository.findByGroupIdAndCurrentOrder(groupId);
     }
 
-    @Transactional(readOnly = true)
-    public List<String> findTokensByPreviousOrder(String groupId, int previousOrder) {
-        return notificationRepository.findByGroupIdAndOrder(groupId, previousOrder);
-    }
-
     @Transactional
     public void saveNotificationToken(NotificationTokenRequest notificationTokenRequest, Long memberId) {
         Member member = memberQueryService.findMember(memberId);

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -60,4 +60,9 @@ public class NotificationTokenService {
                 .build();
         notificationRepository.save(notification);
     }
+
+    @Transactional
+    public void deleteOldTokens() {
+        notificationRepository.deleteAllIfAMonthOld();
+    }
 }

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -20,8 +20,20 @@ public class NotificationTokenService {
     private final MemberQueryService memberQueryService;
 
     @Transactional(readOnly = true)
-    public List<String> findTokensByGroup(String groupId) {
-        return notificationRepository.findTokensByGroupId(groupId);
+    public List<String> findTokensByMemberId(Long memberId) {
+        List<Notification> notifications = notificationRepository.findByMemberId(memberId);
+
+        if (notifications.isEmpty()) {
+            throw new NotFoundException(ErrorCode.FCM_TOKEN_NOT_FOUND, "", String.valueOf(memberId));
+        }
+        return notifications.stream()
+                .map(Notification::getToken)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> findTokensByCurrentOrder(String groupId) {
+        return notificationRepository.findByGroupIdAndCurrentOrder(groupId);
     }
 
     @Transactional(readOnly = true)
@@ -37,23 +49,6 @@ public class NotificationTokenService {
     @Transactional(readOnly = true)
     public List<String> findTokensByCurrentOrderInAllGroup() {
         return notificationRepository.findTokensNoDiaryToday();
-    }
-
-    @Transactional(readOnly = true)
-    public List<String> findTokensByMemberId(Long memberId) {
-        List<Notification> notifications = notificationRepository.findByMemberId(memberId);
-
-        if (notifications.isEmpty()) {
-            throw new NotFoundException(ErrorCode.FCM_TOKEN_NOT_FOUND, "", String.valueOf(memberId));
-        }
-        return notifications.stream()
-                .map(Notification::getToken)
-                .toList();
-    }
-
-    @Transactional(readOnly = true)
-    public List<String> findTokensByCurrentOrder(String groupId) {
-        return notificationRepository.findByGroupIdAndCurrentOrder(groupId);
     }
 
     @Transactional

--- a/src/main/resources/db/migration/V2.8__delete_unique_index_on_notification_member_id.sql
+++ b/src/main/resources/db/migration/V2.8__delete_unique_index_on_notification_member_id.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE notification DROP CONSTRAINT notification_member_id_key;
+
+COMMIT;

--- a/src/test/java/com/exchangediary/notification/api/NotificationApiTest.java
+++ b/src/test/java/com/exchangediary/notification/api/NotificationApiTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class NotificationApiTest extends ApiBaseTest {
@@ -27,8 +29,9 @@ public class NotificationApiTest extends ApiBaseTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 
-        Notification notification = notificationRepository.findByMemberId(member.getId()).get();
-        assertThat(notification.getToken()).isEqualTo("token");
+        List<Notification> notifications = notificationRepository.findByMemberId(member.getId());
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).getToken()).isEqualTo("token");
     }
 
     @Test
@@ -51,7 +54,9 @@ public class NotificationApiTest extends ApiBaseTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 
-        Notification notification = notificationRepository.findByMemberId(member.getId()).get();
-        assertThat(notification.getToken()).isEqualTo("new-token");
+        List<Notification> notifications = notificationRepository.findByMemberId(member.getId());
+        assertThat(notifications).hasSize(2);
+        assertThat(notifications.get(0).getToken()).isEqualTo("old-token");
+        assertThat(notifications.get(1).getToken()).isEqualTo("new-token");
     }
 }

--- a/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
@@ -25,6 +25,27 @@ public class NotificationRepositoryUnitTest {
     private NotificationRepository notificationRepository;
 
     @Test
+    @DisplayName("findByMemberId 동작 확인")
+    void 멤버의_토큰_여러개_가져오기() {
+        Group group = Group.from("버니즈");
+        entityManager.persist(group);
+        Member self = createMember(1, group);
+        entityManager.persist(Notification.builder()
+                .token("token-one")
+                .member(self)
+                .build());
+        entityManager.persist(Notification.builder()
+                .token("token-two")
+                .member(self)
+                .build());
+        entityManager.flush();
+
+        List<Notification> notifications = notificationRepository.findByMemberId(self.getId());
+
+        assertThat(notifications).hasSize(3);
+    }
+
+    @Test
     @DisplayName("findAllTokenByGroupIdExceptMemberId 동작 확인")
     void 본인_제외한_그룹원_토큰_가져오기() {
         Group group = Group.from("버니즈");

--- a/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
@@ -25,22 +25,6 @@ public class NotificationRepositoryUnitTest {
     private NotificationRepository notificationRepository;
 
     @Test
-    @DisplayName("findAllTokenByGroupId 동작 확인")
-    void 전체_그룹원_토큰_가져오기() {
-        Group group = Group.from("버니즈");
-        entityManager.persist(group);
-        createMember(1, group);
-        createMember(2, group);
-        createMember(3, group);
-        createMember(4, group);
-        entityManager.flush();
-
-        List<String> tokens = notificationRepository.findTokensByGroupId(group.getId());
-
-        assertThat(tokens).hasSize(4);
-    }
-
-    @Test
     @DisplayName("findAllTokenByGroupIdExceptMemberId 동작 확인")
     void 본인_제외한_그룹원_토큰_가져오기() {
         Group group = Group.from("버니즈");

--- a/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
@@ -90,20 +90,6 @@ public class NotificationRepositoryUnitTest {
     }
 
     @Test
-    @DisplayName("findByGroupIdAndOrder 동작 확인")
-    void 일기순서_건너뛰어진_그룹원_토큰_가져오기() {
-        Group group = Group.from("버니즈");
-        entityManager.persist(group);
-        createMember(1, group);
-        createMember(2, group);
-        entityManager.flush();
-
-        List<String> tokens = notificationRepository.findByGroupIdAndOrder(group.getId(), 2);
-
-        assertThat(tokens.get(0)).isEqualTo("버니즈2");
-    }
-
-    @Test
     @DisplayName("findAllTokenNoDiaryToday 동작 확인")
     void 오늘_일기_작성하지않은_모든_그룹원_토큰_가져오기() {
         Group group1 = Group.from("그룹1");

--- a/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
@@ -35,7 +35,7 @@ public class NotificationRepositoryUnitTest {
         createMember(4, group);
         entityManager.flush();
 
-        List<String> tokens = notificationRepository.findAllTokenByGroupId(group.getId());
+        List<String> tokens = notificationRepository.findTokensByGroupId(group.getId());
 
         assertThat(tokens).hasSize(4);
     }
@@ -51,7 +51,7 @@ public class NotificationRepositoryUnitTest {
         createMember(4, group);
         entityManager.flush();
 
-        List<String> tokens = notificationRepository.findAllTokenByGroupIdExceptMemberId(group.getId(), self.getId());
+        List<String> tokens = notificationRepository.findTokensByGroupIdExceptMemberId(group.getId(), self.getId());
 
         assertThat(tokens).hasSize(3);
     }
@@ -68,7 +68,7 @@ public class NotificationRepositoryUnitTest {
         createLeader(5, group);
         entityManager.flush();
 
-        List<String> tokens = notificationRepository.findAllTokenByGroupIdExceptMemberIdAndLeader(group.getId(), self.getId());
+        List<String> tokens = notificationRepository.findTokensByGroupIdExceptMemberIdAndLeader(group.getId(), self.getId());
 
         assertThat(tokens).hasSize(3);
     }
@@ -84,9 +84,9 @@ public class NotificationRepositoryUnitTest {
         createMember(4, group);
         entityManager.flush();
 
-        String token = notificationRepository.findByGroupIdAndCurrentOrder(group.getId());
+        List<String> tokens = notificationRepository.findByGroupIdAndCurrentOrder(group.getId());
 
-        assertThat(token).isEqualTo("버니즈1");
+        assertThat(tokens.get(0)).isEqualTo("버니즈1");
     }
 
     @Test
@@ -98,9 +98,9 @@ public class NotificationRepositoryUnitTest {
         createMember(2, group);
         entityManager.flush();
 
-        String token = notificationRepository.findByGroupIdAndOrder(group.getId(), 2);
+        List<String> tokens = notificationRepository.findByGroupIdAndOrder(group.getId(), 2);
 
-        assertThat(token).isEqualTo("버니즈2");
+        assertThat(tokens.get(0)).isEqualTo("버니즈2");
     }
 
     @Test
@@ -118,7 +118,7 @@ public class NotificationRepositoryUnitTest {
         createMember(1, group3);
         entityManager.flush();
 
-        List<String> tokens = notificationRepository.findAllTokenNoDiaryToday();
+        List<String> tokens = notificationRepository.findTokensNoDiaryToday();
 
         assertThat(tokens).hasSize(2);
         assertThat(tokens.contains(group1.getName() + 1)).isFalse();


### PR DESCRIPTION
## Work Description
> 사용자 - 알림 연관관계 변경 및 fcm 토큰 신선도 관리

- Member - Notifcation 엔티티의 연관관계를 일대다로 변경했습니다.
  - 사용자가 여러 장치에 대해 fcm 토큰을 가질 수 있기 때문
- fcm 토큰 신선도 관리를 위해 생성된 지 한 달이 된 토큰은 삭제하도록 구현했습니다.
- 알림, 알림 토큰 서비스에서 다른 메서드를 사용하여 구현 가능한 알림들을 리팩터링했습니다.
  - 일기 건너뛰기 알림
  - 그룹원 가입 알림 

## ISSUE
- closed #393


## Screenshot
#### 테스트 결과
<img width="222" alt="Screenshot 2024-11-14 at 1 24 06 AM" src="https://github.com/user-attachments/assets/be4a8635-375c-428c-baea-62a310738bdb">



## Reference
[FCM 등록 토큰 관리를 위한 권장사항](https://firebase.google.com/docs/cloud-messaging/manage-tokens?hl=ko)
[PostgreSQL DATEDIFF Function](https://www.geeksforgeeks.org/postgresql-datediff-function/)
