### PR TITLE
일기 작성 페이지 엔터 및 백스페이스 기능 개선

### DIFF
--- a/src/main/resources/static/js/diary/write-page/check-textarea.js
+++ b/src/main/resources/static/js/diary/write-page/check-textarea.js
@@ -38,12 +38,22 @@ function checkNextPage(event) {
         if (textarea.value.length === textareaValues[index].length) {
             textareaValues[index] = textareaValues[index].slice(0, -1);
         }
+        const selection = textarea.selectionEnd - 1;
         textarea.value = textareaValues[index];
-        if (index < 4 && event.inputType === "insertLineBreak") {
+        textarea.selectionEnd = selection;
+        if (canTurnPage(index, event)) {
             textarea.blur();
             isCalled = false;
             changePageBySlide("next", "0.3s");
         }
     }
     textareaValues[index] = textarea.value;
+}
+
+function canTurnPage(index, event) {
+    const textarea = event.target
+    if (textarea.selectionEnd !== textarea.value.length) {
+        return false;
+    }
+    return index < 4 && event.inputType === "insertLineBreak";
 }

--- a/src/main/resources/static/js/diary/write-page/check-textarea.js
+++ b/src/main/resources/static/js/diary/write-page/check-textarea.js
@@ -16,7 +16,12 @@ function checkPrevPage(event) {
         const textarea = event.target;
         const index = textareas.indexOf(textarea);
 
-        if (index > 0) {
+        if (textarea.value[0] === "\n") {
+            textareaValues[index] = textarea.value.slice(1);
+            textarea.value = textareaValues[index];
+            textarea.selectionEnd = 0;
+        } 
+        else if (index > 0) {
             textarea.blur();
             changePageBySlide("prev", "0.3s");
         }


### PR DESCRIPTION
## Work Description
> 일기 작성 페이지 엔터 및 백스페이스 기능 개선

- 페이지의 마지막 줄 마지막 글자에서 엔터할 경우에만 다음 페이지로 넘어감
- 첫번째 줄이 개행일때 백스페이스 누르면 개행이 삭제됨

## ISSUE
- closed #396 


## To Reviewers
일기를 작성하며 불편한점이 있거나 개선했으면 하는 부분이 있다면 자유롭게 피드백 달아주세요~

