### PR TITLE
fcm 토큰 없는 경우 메시지 보내지 않도록 수정

### DIFF
--- a/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
@@ -55,11 +55,7 @@ public class DiaryWriteService {
 
             return savedDiary.getId();
         } catch (IOException e) {
-            throw new FailedImageUploadException(
-                    ErrorCode.FAILED_UPLOAD_IMAGE,
-                    "네트워크 오류로 인해 \n일기 업로드에 실패했습니다.\n다시 시도해주세요.",
-                    file.getOriginalFilename()
-            );
+            throw new FailedImageUploadException(ErrorCode.FAILED_UPLOAD_IMAGE, "", file.getOriginalFilename());
         }
     }
 

--- a/src/main/java/com/exchangediary/global/exception/ErrorCode.java
+++ b/src/main/java/com/exchangediary/global/exception/ErrorCode.java
@@ -41,10 +41,8 @@ public enum ErrorCode {
     FAILED_TO_LOGIN_KAKAO(HttpStatus.INTERNAL_SERVER_ERROR, "kakao 로그인에 실패했습니다."),
     FAILED_TO_ISSUE_KAKAO_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "kakao 토큰 발급에 실패했습니다."),
     FAILED_TO_GET_KAKAO_USER_INFO(HttpStatus.INTERNAL_SERVER_ERROR, "kakao 사용자 정보 조회에 실패했습니다."),
-    FAILED_TO_ISSUE_FIREBASE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "firebase 토큰 발급에 실패했습니다."),
     FAILED_TO_SEND_MESSAGE(HttpStatus.INTERNAL_SERVER_ERROR, "메시지 전송에 실패했습니다."),
-    NEED_TO_AT_LEAST_ONE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "하나 이상의 fcm 토큰이 필요합니다."),
-    FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 오류가 발생했습니다.");
+    FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "사진 업로드에 실패했습니다.");
 
     private final HttpStatus statusCode;
     private final String message;

--- a/src/main/java/com/exchangediary/notification/service/MessageSendService.java
+++ b/src/main/java/com/exchangediary/notification/service/MessageSendService.java
@@ -17,24 +17,22 @@ public class MessageSendService {
     private static final String TITLE = "스프링";
 
     public void sendMulticastMessage(List<String> tokens, String body) {
-        if (tokens.isEmpty()) {
-            throw new MessagingFailureException(ErrorCode.NEED_TO_AT_LEAST_ONE_TOKEN, "", null);
-        }
+        if (!tokens.isEmpty()) {
+            Notification notification = Notification.builder()
+                    .setTitle(TITLE)
+                    .setBody(body)
+                    .build();
 
-        Notification notification = Notification.builder()
-                .setTitle(TITLE)
-                .setBody(body)
-                .build();
+            MulticastMessage message = MulticastMessage.builder()
+                    .addAllTokens(tokens)
+                    .setNotification(notification)
+                    .build();
 
-        MulticastMessage message = MulticastMessage.builder()
-                .addAllTokens(tokens)
-                .setNotification(notification)
-                .build();
-
-        try {
-            FirebaseMessaging.getInstance().sendEachForMulticast(message);
-        } catch (FirebaseMessagingException e) {
-            throw new MessagingFailureException(ErrorCode.FAILED_TO_SEND_MESSAGE, "", tokens.toString());
+            try {
+                FirebaseMessaging.getInstance().sendEachForMulticast(message);
+            } catch (FirebaseMessagingException e) {
+                throw new MessagingFailureException(ErrorCode.FAILED_TO_SEND_MESSAGE, "", tokens.toString());
+            }
         }
     }
 }

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -1,7 +1,5 @@
 package com.exchangediary.notification.service;
 
-import com.exchangediary.global.exception.ErrorCode;
-import com.exchangediary.global.exception.serviceexception.NotFoundException;
 import com.exchangediary.member.domain.entity.Member;
 import com.exchangediary.member.service.MemberQueryService;
 import com.exchangediary.notification.domain.NotificationRepository;
@@ -11,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -24,7 +23,7 @@ public class NotificationTokenService {
         List<Notification> notifications = notificationRepository.findByMemberId(memberId);
 
         if (notifications.isEmpty()) {
-            throw new NotFoundException(ErrorCode.FCM_TOKEN_NOT_FOUND, "", String.valueOf(memberId));
+            return new ArrayList<>();
         }
         return notifications.stream()
                 .map(Notification::getToken)


### PR DESCRIPTION
## Work Description
> fcm 토큰 없는 경우 메시지 보내지 않도록 수정

- `findTokensByMemberId` 메서드에서 멤버가 토큰 갖고 있지 않는 경우 예외가 아닌 빈 리스트 반환
- `MessageSendService` 의 `sendMulticastMessage` 메서드에서 토큰이 있는 경우에만 메시지 보내도록 구현

## ISSUE
- closed #406

