### PR TITLE
diary content 테이블 content 열 길이 늘리기

### DIFF
--- a/src/main/resources/db/migration/V2.10__alter_diary_content_content.sql
+++ b/src/main/resources/db/migration/V2.10__alter_diary_content_content.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE diary_content ALTER COLUMN content TYPE character varying(32600);
+
+COMMIT;


### PR DESCRIPTION
## Work Description
> diary content 테이블 content 열 길이 늘리기

- 기존 diary content 테이블의 content 열 길이가 너무 작아 발생한 문제.
- VARCHAR이기 때문에 LONG VARCHAR 길이로 조정해줌

## ISSUE
- closed #415

## To Reviewers
- hotfix이므로 머지 후 바로 서버 재배포 하도록 하겠습니다!


