### PR TITLE
일기 삭제 시 이미지 파일 삭제 및 fcm 토큰 유니크 제약조건 추가

### DIFF
--- a/src/main/java/com/exchangediary/diary/domain/DiaryRepository.java
+++ b/src/main/java/com/exchangediary/diary/domain/DiaryRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<Diary> findByMemberId(Long memberId);
     @Query("SELECT new com.exchangediary.diary.domain.dto.DiaryDay(d.id, d.createdAt, m.profileImage) "+
             "FROM Diary d JOIN d.member m " +
             "WHERE d.group.id = :groupId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month " +

--- a/src/main/java/com/exchangediary/diary/service/DiaryDeleteService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryDeleteService.java
@@ -1,0 +1,29 @@
+package com.exchangediary.diary.service;
+
+import com.exchangediary.diary.domain.DiaryRepository;
+import com.exchangediary.diary.domain.entity.Diary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DiaryDeleteService {
+    private final ImageService imageService;
+    private final DiaryRepository diaryRepository;
+
+    public void deleteDiary(String groupId, Long memberId) {
+        List<Diary> diaries = diaryRepository.findByMemberId(memberId);
+
+        diaryRepository.deleteByMemberId(memberId);
+
+        diaries.forEach(diary -> {
+            if (diary.getImageFileName() != null) {
+                imageService.deleteImage(groupId, diary.getImageFileName());
+            }
+        });
+    }
+}

--- a/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
@@ -8,6 +8,7 @@ import com.exchangediary.diary.domain.entity.DiaryContent;
 import com.exchangediary.diary.ui.dto.request.DiaryRequest;
 import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.global.exception.serviceexception.FailedImageUploadException;
+import com.exchangediary.global.exception.serviceexception.NotFoundException;
 import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.service.GroupQueryService;
@@ -80,7 +81,11 @@ public class DiaryWriteService {
         Member nextWriter = group.getMembers().stream()
                         .filter(member -> group.getCurrentOrder().equals(member.getOrderInGroup()))
                         .findFirst()
-                        .get();
+                        .orElseThrow(() -> new NotFoundException(
+                                ErrorCode.MEMBER_NOT_FOUND,
+                                "현재 순서와 일치하는 멤버가 없습니다.",
+                                String.valueOf(group.getCurrentOrder())
+                        ));
 
         nextWriter.updateLastViewableDiaryDate();
         currentWriter.updateLastViewableDiaryDate();

--- a/src/main/java/com/exchangediary/diary/service/ImageService.java
+++ b/src/main/java/com/exchangediary/diary/service/ImageService.java
@@ -43,6 +43,15 @@ public class ImageService {
         }
     }
 
+    public void deleteImage(String groupId, String fileName) {
+        String imageLocation = String.format(imagePathFormat, fileLocation, groupId) + "/" + fileName;
+
+        File file = new File(imageLocation);
+        if (file.exists()) {
+            file.delete();
+        }
+    }
+
     private boolean isEmptyFile(MultipartFile file) {
         return file == null || file.isEmpty();
     }

--- a/src/main/java/com/exchangediary/group/service/GroupLeaveService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaveService.java
@@ -1,6 +1,6 @@
 package com.exchangediary.group.service;
 
-import com.exchangediary.diary.domain.DiaryRepository;
+import com.exchangediary.diary.service.DiaryDeleteService;
 import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.global.exception.serviceexception.ForbiddenException;
 import com.exchangediary.group.domain.GroupRepository;
@@ -22,14 +22,15 @@ public class GroupLeaveService {
     private final MemberRepository memberRepository;
     private final MemberQueryService memberQueryService;
     private final GroupQueryService groupQueryService;
+    private final DiaryDeleteService diaryDeleteService;
     private final GroupRepository groupRepository;
-    private final DiaryRepository diaryRepository;
 
     public void leaveGroup(String groupId, Long memberId) {
         Group group = groupQueryService.findGroup(groupId);
         Member member = memberQueryService.findMember(memberId);
 
         forbidGroupLeaderLeave(member, group.getMembers().size());
+        diaryDeleteService.deleteDiary(groupId, memberId);
         int leaveMemberOrder = processMemberLeave(member);
         updateGroupAfterMemberLeave(group, leaveMemberOrder);
     }
@@ -42,7 +43,6 @@ public class GroupLeaveService {
 
     private int processMemberLeave(Member member) {
         int orderInGroup = member.getOrderInGroup();
-        diaryRepository.deleteByMemberId(member.getId());
         member.leaveGroup();
         memberRepository.save(member);
         return orderInGroup;

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -6,6 +6,7 @@ import com.exchangediary.notification.domain.NotificationRepository;
 import com.exchangediary.notification.domain.entity.Notification;
 import com.exchangediary.notification.ui.dto.request.NotificationTokenRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,14 +51,17 @@ public class NotificationTokenService {
         return notificationRepository.findTokensNoDiaryToday();
     }
 
-    @Transactional
     public void saveNotificationToken(NotificationTokenRequest notificationTokenRequest, Long memberId) {
         Member member = memberQueryService.findMember(memberId);
         Notification notification = Notification.builder()
                 .token(notificationTokenRequest.token())
                 .member(member)
                 .build();
-        notificationRepository.save(notification);
+
+        try {
+            notificationRepository.save(notification);
+        } catch (DataIntegrityViolationException ignored) {
+        }
     }
 
     @Transactional

--- a/src/main/resources/db/migration/V3.2__add_unique_index_on_token.sql
+++ b/src/main/resources/db/migration/V3.2__add_unique_index_on_token.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE notification ADD CONSTRAINT unique_token UNIQUE (token);
+
+COMMIT;


### PR DESCRIPTION
## Work Description
> 일기 삭제 시 이미지 파일 삭제 및 fcm 토큰 유니크 제약조건 추가

- 일기가 삭제되어도 이미지 파일은 남아있어 불필요하게 메모리를 차지했습니다. 
따라서 일기 삭제 시 이미지 파일도 함께 삭제해주었습니다.
- fcm 토큰에 유니크 제약조건을 추가하여, 중복되는 fcm 토큰 레코드가 DB에 쌓이지 않도록 했습니다.

## ISSUE
- closed #414 

