### PR TITLE
일기 작성 권한 없는 경우 오늘 날짜 클릭되는 오류 해결

### DIFF
--- a/src/main/resources/static/js/group/monthly/draw-bottom.js
+++ b/src/main/resources/static/js/group/monthly/draw-bottom.js
@@ -1,3 +1,5 @@
+let canWrite = true;
+
 function drawBottom() {
     const calendarBottom = document.querySelector(".calendar-bottom")
 
@@ -6,9 +8,9 @@ function drawBottom() {
         .then(data => {
             calendarBottom.innerHTML = getCalendarBottomHtml(data);
 
-            if (!data.isMyOrder && data.viewableDiaryId == null) {
-                const today = document.querySelector(".today");
-                today.classList.add("cannot-view");
+            canWrite = (data.isMyOrder && data.viewableDiaryId == null);
+            if (!canWrite) {
+                removeClickToday();
             }
         });
 }

--- a/src/main/resources/static/js/group/monthly/draw-monthly.js
+++ b/src/main/resources/static/js/group/monthly/draw-monthly.js
@@ -35,6 +35,7 @@ async function drawDateOfCalendar() {
     }
     changeGrayProfile(writtenDiaryDays);
     addBorderToday();
+    removeClickToday();
 }
 
 function clearDate() {
@@ -79,6 +80,7 @@ function isToday(date) {
 function changeGrayProfile(days) {
     days.forEach(day => {
        if (!day.canView) {
+           console.log(day);
            const dayBtn = document.querySelector(`.day${day.day}`);
 
            dayBtn.classList.add("cannot-view");
@@ -94,6 +96,14 @@ function addBorderToday() {
         const column = Math.floor((todayDate + firstDay) / 7);
         const row = (todayDate + firstDay) % 7;
         trs[column].children[row].querySelector("a").classList.add("today");
+    }
+}
+
+function removeClickToday() {
+    const today = document.querySelector(".today");
+
+    if (today && !canWrite) {
+        today.classList.add("cannot-view");
     }
 }
 


### PR DESCRIPTION
## Work Description
> 한 줄 요약

- 원인) 초기 바텀시트 그릴 때 한 번만 처리해서 발생하는 
- 해결) 바텀시트 그릴 때, 오늘 날짜 클릭 가능한 지 값 저장 후, 달력 그릴때마다 오늘 날짜 클릭 비활성화되도록하여 문제 해결

## ISSUE
- closed #447


## Screenshot

https://github.com/user-attachments/assets/b3a1b9dd-537e-47de-817b-9a9964fc4782




## To Reviewers
왕오랜만의 pr ~ 다시 달려봅시다!!! 화이팅 👏
