### PR TITLE
댓글/답글 알림 구현

### DIFF
--- a/src/main/java/com/exchangediary/comment/service/CommentCreateService.java
+++ b/src/main/java/com/exchangediary/comment/service/CommentCreateService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class CommentService {
+public class CommentCreateService {
     private final MemberQueryService memberQueryService;
     private final DiaryQueryService diaryQueryService;
     private final DiaryAuthorizationService diaryAuthorizationService;

--- a/src/main/java/com/exchangediary/comment/ui/ApiCommentController.java
+++ b/src/main/java/com/exchangediary/comment/ui/ApiCommentController.java
@@ -1,13 +1,15 @@
 package com.exchangediary.comment.ui;
 
 import com.exchangediary.comment.service.CommentQueryService;
-import com.exchangediary.comment.service.CommentService;
+import com.exchangediary.comment.service.CommentCreateService;
 import com.exchangediary.comment.service.ReplyCreateService;
 import com.exchangediary.comment.ui.dto.request.CommentCreateRequest;
 import com.exchangediary.comment.ui.dto.request.ReplyCreateRequest;
 import com.exchangediary.comment.ui.dto.response.CommentCreateResponse;
 import com.exchangediary.comment.ui.dto.response.CommentCreationVerifyResponse;
 import com.exchangediary.comment.ui.dto.response.CommentResponse;
+import com.exchangediary.diary.service.DiaryQueryService;
+import com.exchangediary.notification.service.NotificationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,9 +26,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/groups/{groupId}/diaries/{diaryId}/comments")
 public class ApiCommentController {
-    private final CommentService commentService;
-    private final ReplyCreateService replyCreateService;
+    private final DiaryQueryService diaryQueryService;
     private final CommentQueryService commentQueryService;
+    private final CommentCreateService commentCreateService;
+    private final ReplyCreateService replyCreateService;
+    private final NotificationService notificationService;
 
     @PostMapping
     public ResponseEntity<CommentCreateResponse> createComment(
@@ -34,7 +38,8 @@ public class ApiCommentController {
             @RequestBody @Valid CommentCreateRequest request,
             @RequestAttribute Long memberId
     ) {
-        CommentCreateResponse response = commentService.createComment(request, diaryId, memberId);
+        CommentCreateResponse response = commentCreateService.createComment(request, diaryId, memberId);
+        notificationService.pushNotification(diaryQueryService.findDiary(diaryId).getMember().getId(), "친구가 내 일기에 댓글을 달았어요!");
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(response);

--- a/src/main/java/com/exchangediary/comment/ui/ApiCommentController.java
+++ b/src/main/java/com/exchangediary/comment/ui/ApiCommentController.java
@@ -76,6 +76,8 @@ public class ApiCommentController {
             @RequestAttribute Long memberId
     ) {
         replyCreateService.createReply(request, diaryId, commentId, memberId);
+        notificationService.pushNotification(commentQueryService.findComment(commentId).getMember().getId(), "친구가 내 댓글에 답글을 달았어요!");
+        notificationService.pushNotification(diaryQueryService.findDiary(diaryId).getMember().getId(), "친구가 내 일기의 댓글에 답글을 달았어요!");
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .build();


### PR DESCRIPTION
## Work Description
> 댓글/답글 알림 구현

- 댓글 및 답글 작성 시 알림 구현했습니다.
- 기존에 구현해둔 notificationService의 pushNotification 메서드를 재사용했습니다.

## ISSUE
- closed #371


## Screenshot
직접 댓글 및 답글을 작성하면서 알림 테스트해보았습니다.
<img width="358" alt="Screenshot 2025-02-07 at 12 55 02 AM" src="https://github.com/user-attachments/assets/cc447d6f-aa96-4246-8222-9c1bf2c05082" />
        

## To Reviewers
- 추후 모든 알림 메시지 수정 예정입니다. 또한 알림 목록 [노션](https://www.notion.so/glory-banana-f15/43253cc96545440c962dd1d59a338b80?pvs=4)에 정리했습니다.
- pushNotification 메서드를 재사용하고싶어 일기 작성자와 댓글 작성자를 조회하는 부분에서 불필요하게 데이터베이스를 조회하고 있습니다. 이 부분은 member 데이터베이스 구조 변경 후, 다시 고민해 볼 예정입니다.
