### PR TITLE
리다이렉트 제거

### DIFF
--- a/src/main/java/com/exchangediary/global/config/web/WebConfig.java
+++ b/src/main/java/com/exchangediary/global/config/web/WebConfig.java
@@ -25,7 +25,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${file.resources.location}")
     private String location;
 
-
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/upload/**")
@@ -35,10 +34,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new JwtAuthenticationInterceptor(jwtService, cookieService, memberQueryService))
-                .addPathPatterns("/login", "/groups", "/diaries/**", "/groups/**", "/api/**")
+                .addPathPatterns("/api/**")
                 .excludePathPatterns("/api/kakao/callback");
         registry.addInterceptor(new GroupAuthorizationInterceptor(memberQueryService))
-                .addPathPatterns("/groups/**", "/api/groups/*/**")
+                .addPathPatterns("/api/groups/*/**")
                 .excludePathPatterns(
                         "/api/groups/*/profile-image",
                         "/api/groups/*/nickname/verify",

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/GroupAuthorizationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/GroupAuthorizationInterceptor.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 
@@ -23,56 +22,26 @@ public class GroupAuthorizationInterceptor implements HandlerInterceptor {
             HttpServletRequest request,
             HttpServletResponse response,
             Object handler
-    ) throws IOException {
-        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-        Long memberId = (Long) request.getAttribute("memberId");
-        Optional<String> memberGroupId = memberQueryService.findGroupBelongTo(memberId);
-
-        handleNotExistRequestUrl(pathVariables, request.getRequestURI());
-        if (isGroupCreatePageRequest(pathVariables)) {
-            return processGroupCreatePageRequest(memberGroupId.orElse(null), response);
-        }
-
-        String groupId = String.valueOf(pathVariables.get("groupId"));
-        if (memberGroupId.isEmpty()) {
-            response.sendRedirect("/groups");
-            return false;
-        }
-        return processGroupAuthorization(groupId, memberGroupId.get(), request);
-    }
-
-    private void handleNotExistRequestUrl(Map<String, String> pathVariables, String url) {
-        if (pathVariables == null) {
-            throw new NotFoundException(ErrorCode.NOT_FOUND, "", url);
-        }
-    }
-
-    private boolean isGroupCreatePageRequest(Map<String, String> pathVariables) {
-        return !pathVariables.containsKey("groupId");
-    }
-
-    private boolean processGroupCreatePageRequest(String memberGroupId, HttpServletResponse response) throws IOException {
-        if (memberGroupId == null) {
-            return true;
-        }
-        response.sendRedirect("/groups/" + memberGroupId);
-        return false;
-    }
-
-    private boolean processGroupAuthorization(
-            String groupId,
-            String memberGroupId,
-            HttpServletRequest request
     ) {
-        if (!groupId.equals(memberGroupId)) {
-            throw new ForbiddenException(
-                    ErrorCode.GROUP_FORBIDDEN,
-                    "",
-                    request.getRequestURI()
-            );
-        }
+        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        String groupIdInUri = extractGroupId(pathVariables, request.getRequestURI());
 
-        request.setAttribute("groupId", groupId);
+        Long memberId = (Long) request.getAttribute("memberId");
+        Optional<String> memberGroupId = memberQueryService.findGroupIdBelongTo(memberId);
+
+        if (memberGroupId.isEmpty() || !memberGroupId.get().equals(groupIdInUri)) {
+            throw new ForbiddenException(ErrorCode.GROUP_FORBIDDEN, "", groupIdInUri);
+        }
         return true;
+    }
+
+    private String extractGroupId(Map<String, String> pathVariables, String uri) {
+        if (pathVariables == null) {
+            throw new NotFoundException(ErrorCode.NOT_FOUND, "URI에 path variables 없음", uri);
+        }
+        if (!pathVariables.containsKey("groupId")) {
+            throw new NotFoundException(ErrorCode.NOT_FOUND, "URI에 그룹 id 포함되어 있지 않음", uri);
+        }
+        return String.valueOf(pathVariables.get("groupId"));
     }
 }

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
@@ -12,8 +12,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import java.io.IOException;
-
 @RequiredArgsConstructor
 public class JwtAuthenticationInterceptor implements HandlerInterceptor {
     private static final String COOKIE_NAME = "token";
@@ -29,42 +27,12 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
             HttpServletRequest request,
             HttpServletResponse response,
             Object handler
-    ) throws IOException {
-        try {
-            token = getJwtTokenFromCookies(request);
-            verifyAndReissueAccessToken(response);
-            Long memberId = jwtService.extractMemberId(token);
-            checkMemberExists(memberId);
-            request.setAttribute("memberId", memberId);
-        } catch (UnauthorizedException exception) {
-            return processAuthorizationFail(request, response, exception);
-        }
-        return processAuthorizationSuccess(request, response);
-    }
-
-    private boolean processAuthorizationFail(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            UnauthorizedException exception
-    ) throws IOException {
-        if (request.getRequestURI().equals("/login")) {
-            return true;
-        }
-        if (request.getRequestURI().contains("/api")) {
-            throw exception;
-        }
-        response.sendRedirect(request.getContextPath()+ "/");
-        return false;
-    }
-
-    private boolean processAuthorizationSuccess(
-            HttpServletRequest request,
-            HttpServletResponse response
-    ) throws IOException {
-        if (request.getRequestURI().equals("/login")) {
-            response.sendRedirect(request.getContextPath()+ "/groups");
-            return false;
-        }
+    ) {
+        token = getJwtTokenFromCookies(request);
+        verifyAndReissueAccessToken(response);
+        Long memberId = jwtService.extractMemberId(token);
+        checkMemberExists(memberId);
+        request.setAttribute("memberId", memberId);
         return true;
     }
 

--- a/src/main/java/com/exchangediary/member/service/MemberQueryService.java
+++ b/src/main/java/com/exchangediary/member/service/MemberQueryService.java
@@ -31,7 +31,7 @@ public class MemberQueryService {
         return memberRepository.existsById(memberId);
     }
 
-    public Optional<String> findGroupBelongTo(Long memberId) {
+    public Optional<String> findGroupIdBelongTo(Long memberId) {
         return memberRepository.findGroupIdById(memberId)
                 .map(GroupId::groupId);
     }

--- a/src/main/java/com/exchangediary/member/ui/ApiKakaoLoginController.java
+++ b/src/main/java/com/exchangediary/member/ui/ApiKakaoLoginController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/kakao")
-public class KakaoLoginController {
+public class ApiKakaoLoginController {
     private final KakaoService kakaoService;
     private final MemberRegistrationService memberRegistrationService;
     private final JwtService jwtService;

--- a/src/main/java/com/exchangediary/member/ui/KakaoLoginController.java
+++ b/src/main/java/com/exchangediary/member/ui/KakaoLoginController.java
@@ -7,6 +7,8 @@ import com.exchangediary.member.service.MemberRegistrationService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,15 +24,19 @@ public class KakaoLoginController {
     private final CookieService cookieService;
 
     @GetMapping("/callback")
-    public String callback(
+    public ResponseEntity<String> callback(
             @RequestParam String code,
             HttpServletResponse response
     ) {
         Long kakaoId = kakaoService.loginKakao(code);
         Long memberId = memberRegistrationService.getOrCreateMember(kakaoId).memberId();
         String token = jwtService.generateAccessToken(memberId);
+
         Cookie cookie = cookieService.createCookie("token", token);
         response.addCookie(cookie);
-        return "redirect:/groups";
+        return ResponseEntity
+                .status(HttpStatus.FOUND)
+                .header("Location", "/")
+                .build();
     }
 }

--- a/src/test/java/com/exchangediary/ApiBaseTest.java
+++ b/src/test/java/com/exchangediary/ApiBaseTest.java
@@ -3,12 +3,10 @@ package com.exchangediary;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.domain.entity.Member;
 import com.exchangediary.member.service.JwtService;
-import com.exchangediary.notification.service.NotificationService;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -23,8 +21,6 @@ public class ApiBaseTest {
     protected MemberRepository memberRepository;
     @Autowired
     private JwtService jwtService;
-    @MockBean
-    private NotificationService notificationService;
 
     protected Member member;
     protected String token;

--- a/src/test/java/com/exchangediary/global/config/interceptor/GroupAuthorizationInterceptorTest.java
+++ b/src/test/java/com/exchangediary/global/config/interceptor/GroupAuthorizationInterceptorTest.java
@@ -6,111 +6,50 @@ import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.domain.enums.GroupRole;
 import io.restassured.RestAssured;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 public class GroupAuthorizationInterceptorTest extends ApiBaseTest {
+    private final String URI = "/api/groups/%s/members";
     @Autowired
     private GroupRepository groupRepository;
     @Autowired
     private MemberRepository memberRepository;
+    private String groupId;
+
+    @BeforeEach
+    void joinGroup() {
+        Group group = createGroup();
+        updateSelf(group);
+        groupId = group.getId();
+    }
 
     @Test
-    void 그룹_가입하지_않은_사용자가_그룹생성가입페이지_접근() {
+    void 본인이_가입한_그룹_API_요청() {
         RestAssured
                 .given().log().all()
                 .cookie("token", token)
-                .redirects().follow(false)
-                .when().get("/groups")
+                .when().get(String.format(URI, groupId))
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
 
     @Test
-    void 그룹_가입한_사용자가_그룹월별형페이지_접근() {
+    void 본인이_가입하지않은_그룹_API_요청 () {
         Group group = createGroup();
-        updateSelf(group);
 
         RestAssured
                 .given().log().all()
                 .cookie("token", token)
-                .redirects().follow(false)
-                .when().get("/groups/" + group.getId())
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value());
-    }
-
-    @Test
-    void 그룹_가입한_사용자가_그룹생성가입페이지_접근() {
-        Group group = createGroup();
-        updateSelf(group);
-
-        String location = RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .redirects().follow(false)
-                .when().get("/groups")
-                .then()
-                .log().status()
-                .log().headers()
-                .statusCode(HttpStatus.FOUND.value())
-                .extract()
-                .header("location");
-
-        Assertions.assertThat(location.substring(location.indexOf("/groups"))).isEqualTo("/groups/" + group.getId());
-    }
-
-    @Test
-    void 그룹_가입하지_않은_사용자가_그룹월별형페이지_접근() {
-        Group group = createGroup();
-
-        String location = RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .redirects().follow(false)
-                .when().get("/groups/" + group.getId())
-                .then()
-                .log().status()
-                .log().headers()
-                .statusCode(HttpStatus.FOUND.value())
-                .extract()
-                .header("location");
-
-        Assertions.assertThat(location.substring(location.indexOf("/groups"))).isEqualTo("/groups");
-    }
-
-    @Test
-    void 그룹_속한_멤버_api_접근 () {
-        Group group = createGroup();
-        updateSelf(group);
-
-        RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .redirects().follow(false)
-                .when().get(String.format("api/groups/%s/diaries/status", group.getId()))
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value());
-    }
-
-    @Test
-    void 그룹_속하지_않은_멤버_api_접근 () {
-        Group group = createGroup();
-        Group otherGroup = createGroup();
-        updateSelf(group);
-
-        RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .when().get(String.format("api/groups/%s/diaries/status", otherGroup.getId()))
+                .when().get(String.format(URI, group.getId()))
                 .then().log().all()
                 .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     @Test
-    void 그룹_속한_멤버_일기에_접근 () {
+    void 그룹_가입하지않은_사용자의_API_요청 () {
         Group group = createGroup();
         updateSelf(group);
 
@@ -118,54 +57,8 @@ public class GroupAuthorizationInterceptorTest extends ApiBaseTest {
                 .given().log().all()
                 .cookie("token", token)
                 .redirects().follow(false)
-                .when().get(String.format("/groups/%s/diaries", group.getId()))
+                .when().get(String.format(URI, groupId))
                 .then().log().all()
-                .statusCode(HttpStatus.OK.value());
-    }
-
-    @Test
-    void 그룹_속하지_않은_멤버_일기에_접근() {
-        Group group = createGroup();
-        Group otherGroup = createGroup();
-        updateSelf(group);
-
-        RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .redirects().follow(false)
-                .when().get(String.format("/groups/%s/diaries", otherGroup.getId()))
-                .then()
-                .log().all()
-                .statusCode(HttpStatus.FORBIDDEN.value());
-    }
-
-    @Test
-    void 그룹_속한_멤버_월별형_접근 () {
-        Group group = createGroup();
-        updateSelf(group);
-
-        RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .redirects().follow(false)
-                .when().get("/groups/" + group.getId())
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value());
-    }
-
-    @Test
-    void 그룹_속하지_않은_멤버_월별형_접근() {
-        Group group = createGroup();
-        Group otherGroup = createGroup();
-        updateSelf(group);
-
-        RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .redirects().follow(false)
-                .when().get("/groups/" + otherGroup.getId())
-                .then()
-                .log().all()
                 .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
@@ -178,7 +71,7 @@ public class GroupAuthorizationInterceptorTest extends ApiBaseTest {
                 "me",
                 "red",
                 1,
-                GroupRole.GROUP_MEMBER,
+                GroupRole.GROUP_LEADER,
                 group
         );
         memberRepository.save(this.member);

--- a/src/test/java/com/exchangediary/global/config/interceptor/JwtAuthenticationInterceptorTest.java
+++ b/src/test/java/com/exchangediary/global/config/interceptor/JwtAuthenticationInterceptorTest.java
@@ -1,6 +1,8 @@
 package com.exchangediary.global.config.interceptor;
 
 import com.exchangediary.ApiBaseTest;
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.member.domain.RefreshTokenRepository;
 import com.exchangediary.member.domain.entity.RefreshToken;
 import com.exchangediary.member.service.JwtService;
@@ -9,6 +11,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,50 +27,33 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JwtAuthenticationInterceptorTest extends ApiBaseTest {
+    private final String URI = "/api/groups/%s/profile-image";
     @Value("${security.jwt.secret-key}")
     private String secretKey;
     @Autowired
     private JwtService jwtService;
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    private GroupRepository groupRepository;
+    private String groupId;
 
-    @Test
-    void 토큰_발급받은_사용자가_로그인_페이지_접근() {
-        String location = RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .redirects().follow(false)
-                .when().get("/login")
-                .then()
-                .log().status()
-                .log().headers()
-                .statusCode(HttpStatus.FOUND.value())
-                .extract()
-                .header("location");
-
-        assertThat(location.substring(location.indexOf("/groups"))).isEqualTo("/groups");
-    }
-
-    @Test
-    void 토큰_발급받지않은_사용자가_로그인_페이지_접근() {
-        RestAssured
-                .given().log().all()
-                .cookie("token", token)
-                .when().get("/login")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value());
+    @BeforeEach
+    void createGroup() {
+        Group group = Group.from("버니즈");
+        groupRepository.save(group);
+        this.groupId = group.getId();
     }
 
     @Test
     void 인증_실패_쿠키에_토큰없음() {
         RestAssured
                 .given().log().all()
-                .redirects().follow(false)
-                .when().get("/groups")
+                .when().get(String.format(URI, groupId))
                 .then()
                 .log().status()
                 .log().headers()
-                .statusCode(HttpStatus.FOUND.value());
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
     @ParameterizedTest
@@ -76,12 +62,11 @@ public class JwtAuthenticationInterceptorTest extends ApiBaseTest {
         RestAssured
                 .given().log().all()
                 .cookie("token", token)
-                .redirects().follow(false)
-                .when().get("/groups")
+                .when().get(String.format(URI, groupId))
                 .then()
                 .log().status()
                 .log().headers()
-                .statusCode(HttpStatus.FOUND.value());
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
     @Test
@@ -90,7 +75,7 @@ public class JwtAuthenticationInterceptorTest extends ApiBaseTest {
         RestAssured
                 .given().log().all()
                 .cookie("token", this.token)
-                .when().get("/groups")
+                .when().get(String.format(URI, groupId))
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
@@ -105,7 +90,7 @@ public class JwtAuthenticationInterceptorTest extends ApiBaseTest {
         String token = RestAssured
                 .given().log().all()
                 .cookie("token", this.token)
-                .when().get("/groups")
+                .when().get(String.format(URI, groupId))
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
@@ -123,12 +108,11 @@ public class JwtAuthenticationInterceptorTest extends ApiBaseTest {
         RestAssured
                 .given().log().all()
                 .cookie("token", this.token)
-                .redirects().follow(false)
-                .when().get("/groups")
+                .when().get(String.format(URI, groupId))
                 .then()
                 .log().status()
                 .log().headers()
-                .statusCode(HttpStatus.FOUND.value());
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
     @Test
@@ -141,12 +125,11 @@ public class JwtAuthenticationInterceptorTest extends ApiBaseTest {
         RestAssured
                 .given().log().all()
                 .cookie("token", this.token)
-                .redirects().follow(false)
-                .when().get("/groups")
+                .when().get(String.format(URI, groupId))
                 .then()
                 .log().status()
                 .log().headers()
-                .statusCode(HttpStatus.FOUND.value());
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
 
         Optional<RefreshToken> result = refreshTokenRepository.findByMemberId(member.getId());
         assertThat(result.isEmpty()).isTrue();
@@ -159,23 +142,10 @@ public class JwtAuthenticationInterceptorTest extends ApiBaseTest {
         RestAssured
                 .given().log().all()
                 .cookie("token", this.token)
-                .redirects().follow(false)
-                .when().get("/groups")
+                .when().get(String.format(URI, groupId))
                 .then()
                 .log().status()
                 .log().headers()
-                .statusCode(HttpStatus.FOUND.value());
-    }
-
-    @Test
-    void API_요청_인증_실패시_401_응답() {
-        this.token = buildExpiredAccessToken();
-
-        RestAssured
-                .given().log().all()
-                .cookie("token", this.token)
-                .when().post("/api/groups")
-                .then().log().all()
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
@@ -199,7 +169,7 @@ public class JwtAuthenticationInterceptorTest extends ApiBaseTest {
         return Jwts
                 .builder()
                 .setIssuedAt(now)
-                .setExpiration(expiration )
+                .setExpiration(expiration)
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }


### PR DESCRIPTION
## Work Description
> 리다이렉트 제거

- 백엔드에서, 특히 인터셉터에서 사용되고 있던 리다이렉트를 모두 제거했습니다.
- 인증 인터셉터, 그룹 인가 인터셉터 테스트를 수정했습니다.

## ISSUE
- closed #461 


## Screenshot
- 테스트 결과입니다.
<img width="702" alt="Screenshot 2025-02-10 at 8 05 48 PM" src="https://github.com/user-attachments/assets/e1bb171b-4c19-4fa4-845f-88d640458617" />



## To Reviewers
- KakaoLoginController의 리다이렉트를 남겨두었는데, 이 부분은 login API 의 추가 및 수정이 필요하다고 판단하여 프론트랑 추후 논의 후, 수정하면서 제거하도록 하겠습니다.

