### PR TITLE
익명의 사용자 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/exchangediary/global/config/web/WebConfig.java
+++ b/src/main/java/com/exchangediary/global/config/web/WebConfig.java
@@ -36,7 +36,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new JwtAuthenticationInterceptor(jwtService, cookieService, memberQueryService))
                 .addPathPatterns("/login", "/groups", "/diaries/**", "/groups/**", "/api/**")
-                .excludePathPatterns("/api/kakao/callback");
+                .excludePathPatterns("/api/kakao/callback", "/api/anonymous/info");
         registry.addInterceptor(new GroupAuthorizationInterceptor(memberQueryService))
                 .addPathPatterns("/groups/**", "/api/groups/*/**")
                 .excludePathPatterns(

--- a/src/main/java/com/exchangediary/global/config/web/WebConfig.java
+++ b/src/main/java/com/exchangediary/global/config/web/WebConfig.java
@@ -34,8 +34,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new JwtAuthenticationInterceptor(jwtService, cookieService, memberQueryService))
-                .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/kakao/callback", "/api/anonymous/info");
+                .addPathPatterns("/**", "/api/**")
+                .excludePathPatterns("/", "/login", "/api/kakao/callback", "/api/anonymous/info");
         registry.addInterceptor(new GroupAuthorizationInterceptor(memberQueryService))
                 .addPathPatterns("/api/groups/*/**")
                 .excludePathPatterns(

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
@@ -28,6 +28,7 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
 
         if (newToken != null) {
             cookieService.addCookie(jwtService.COOKIE_NAME, newToken, response);
+            token = newToken;
         }
 
         Long memberId = jwtService.extractMemberId(token);

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
@@ -15,8 +15,6 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationInterceptor implements HandlerInterceptor {
-    private static final String COOKIE_NAME = "token";
-
     private final JwtService jwtService;
     private final CookieService cookieService;
     private final MemberQueryService memberQueryService;
@@ -32,7 +30,7 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
             String newToken = jwtService.verifyAccessToken(token);
 
             if (newToken != null) {
-                cookieService.addCookie(COOKIE_NAME, newToken, response);
+                cookieService.addCookie(jwtService.COOKIE_NAME, newToken, response);
             }
 
             Long memberId = jwtService.extractMemberId(token);
@@ -74,12 +72,12 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
         try {
             Cookie[] cookies = request.getCookies();
 
-            return cookieService.getValueFromCookies(cookies, COOKIE_NAME);
+            return cookieService.getValueFromCookies(cookies, jwtService.COOKIE_NAME);
         } catch (RuntimeException exception) {
             throw new UnauthorizedException(
                     ErrorCode.NEED_TO_REQUEST_TOKEN,
                     "",
-                    COOKIE_NAME
+                    jwtService.COOKIE_NAME
             );
         }
     }

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
@@ -29,7 +29,12 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
     ) throws IOException {
         try {
             String token = getJwtTokenFromCookies(request);
-            verifyAndReissueAccessToken(token, response);
+            String newToken = jwtService.verifyAccessToken(token);
+
+            if (newToken != null) {
+                cookieService.addCookie(COOKIE_NAME, newToken, response);
+            }
+
             Long memberId = jwtService.extractMemberId(token);
             checkMemberExists(memberId);
             request.setAttribute("memberId", memberId);
@@ -76,15 +81,6 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
                     "",
                     COOKIE_NAME
             );
-        }
-    }
-
-    private void verifyAndReissueAccessToken(String token, HttpServletResponse response) {
-        String newToken = jwtService.verifyAccessToken(token);
-
-        if (newToken != null) {
-            Cookie cookie = cookieService.createCookie(COOKIE_NAME, newToken);
-            response.addCookie(cookie);
         }
     }
 

--- a/src/main/java/com/exchangediary/member/service/AnonymousService.java
+++ b/src/main/java/com/exchangediary/member/service/AnonymousService.java
@@ -1,0 +1,39 @@
+package com.exchangediary.member.service;
+
+import com.exchangediary.global.exception.serviceexception.UnauthorizedException;
+import com.exchangediary.member.ui.dto.response.AnonymousInfoResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnonymousService {
+    private final CookieService cookieService;
+    private final JwtService jwtService;
+    private final MemberQueryService memberQueryService;
+
+    public AnonymousInfoResponse viewAnonymousInfo(String token, HttpServletResponse response) {
+        String groupId = null;
+        boolean shouldLogin = needLogin(token, response);
+
+        if (!shouldLogin) {
+            Long memberId = jwtService.extractMemberId(token);
+            groupId = memberQueryService.findGroupBelongTo(memberId).orElse(null);
+        }
+        return AnonymousInfoResponse.of(shouldLogin, groupId);
+    }
+
+    private boolean needLogin(String token, HttpServletResponse response) {
+        try {
+            token = jwtService.verifyAccessToken(token);
+
+            if (token != null) {
+                cookieService.addCookie(jwtService.COOKIE_NAME, token, response);
+            }
+        } catch (UnauthorizedException exception) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/exchangediary/member/service/CookieService.java
+++ b/src/main/java/com/exchangediary/member/service/CookieService.java
@@ -1,6 +1,7 @@
 package com.exchangediary.member.service;
 
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -10,6 +11,11 @@ import java.util.Arrays;
 public class CookieService {
     @Value("${cookie.max-age.millisecond}")
     private int maxAgeInMilliseconds;
+
+    public void addCookie(String name, String value, HttpServletResponse response) {
+        Cookie cookie = createCookie(name, value);
+        response.addCookie(cookie);
+    }
 
     public Cookie createCookie(String name, String value) {
         Cookie cookie = new Cookie(name, value);

--- a/src/main/java/com/exchangediary/member/service/JwtService.java
+++ b/src/main/java/com/exchangediary/member/service/JwtService.java
@@ -20,6 +20,7 @@ import java.util.Date;
 @Service
 @RequiredArgsConstructor
 public class JwtService {
+    public final String COOKIE_NAME = "token";
     @Value("${security.jwt.secret-key}")
     private String secretKey;
     @Value("${security.jwt.access-token.expiration-time}")

--- a/src/main/java/com/exchangediary/member/service/MemberRegistrationService.java
+++ b/src/main/java/com/exchangediary/member/service/MemberRegistrationService.java
@@ -30,14 +30,16 @@ public class MemberRegistrationService {
     }
 
     private void issueRefreshToken(Member member) {
+        String token = jwtService.generateRefreshToken();
+
         refreshTokenRepository.findByMemberId(member.getId())
                 .ifPresentOrElse(
                         refreshToken -> {
-                            refreshToken.reissueToken(jwtService.generateRefreshToken());
+                            refreshToken.reissueToken(token);
                             refreshTokenRepository.save(refreshToken);
                         },
                         () -> {
-                            RefreshToken refreshToken = RefreshToken.of(jwtService.generateRefreshToken(), member);
+                            RefreshToken refreshToken = RefreshToken.of(token, member);
                             refreshTokenRepository.save(refreshToken);
                         }
                 );

--- a/src/main/java/com/exchangediary/member/ui/ApiAnonymousController.java
+++ b/src/main/java/com/exchangediary/member/ui/ApiAnonymousController.java
@@ -1,0 +1,30 @@
+package com.exchangediary.member.ui;
+
+import com.exchangediary.member.service.AnonymousService;
+import com.exchangediary.member.ui.dto.response.AnonymousInfoResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/anonymous")
+public class ApiAnonymousController {
+    private final AnonymousService anonymousService;
+
+    @GetMapping("/info")
+    public ResponseEntity<AnonymousInfoResponse> viewAnonymousInfo(
+            @CookieValue(value = "token", required = false) String token,
+            HttpServletResponse response
+    ) {
+        AnonymousInfoResponse anonymousInfoResponse = anonymousService.viewAnonymousInfo(token, response);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(anonymousInfoResponse);
+    }
+}

--- a/src/main/java/com/exchangediary/member/ui/KakaoLoginController.java
+++ b/src/main/java/com/exchangediary/member/ui/KakaoLoginController.java
@@ -30,7 +30,7 @@ public class KakaoLoginController {
         Long memberId = memberRegistrationService.getOrCreateMember(kakaoId).memberId();
         String token = jwtService.generateAccessToken(memberId);
 
-        cookieService.addCookie("token", token, response);
+        cookieService.addCookie(jwtService.COOKIE_NAME, token, response);
         return "redirect:/groups";
     }
 }

--- a/src/main/java/com/exchangediary/member/ui/KakaoLoginController.java
+++ b/src/main/java/com/exchangediary/member/ui/KakaoLoginController.java
@@ -29,8 +29,8 @@ public class KakaoLoginController {
         Long kakaoId = kakaoService.loginKakao(code);
         Long memberId = memberRegistrationService.getOrCreateMember(kakaoId).memberId();
         String token = jwtService.generateAccessToken(memberId);
-        Cookie cookie = cookieService.createCookie("token", token);
-        response.addCookie(cookie);
+
+        cookieService.addCookie("token", token, response);
         return "redirect:/groups";
     }
 }

--- a/src/main/java/com/exchangediary/member/ui/dto/response/AnonymousInfoResponse.java
+++ b/src/main/java/com/exchangediary/member/ui/dto/response/AnonymousInfoResponse.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record AnonymousInfoResponse(
-        boolean shouldLogin,
+        Boolean shouldLogin,
         String groupId
 ) {
     public static AnonymousInfoResponse of(boolean shouldLogin, String groupId) {

--- a/src/main/java/com/exchangediary/member/ui/dto/response/AnonymousInfoResponse.java
+++ b/src/main/java/com/exchangediary/member/ui/dto/response/AnonymousInfoResponse.java
@@ -1,0 +1,16 @@
+package com.exchangediary.member.ui.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AnonymousInfoResponse(
+        boolean shouldLogin,
+        String groupId
+) {
+    public static AnonymousInfoResponse of(boolean shouldLogin, String groupId) {
+        return AnonymousInfoResponse.builder()
+                .shouldLogin(shouldLogin)
+                .groupId(groupId)
+                .build();
+    }
+}

--- a/src/test/java/com/exchangediary/member/api/AnonymousApiTest.java
+++ b/src/test/java/com/exchangediary/member/api/AnonymousApiTest.java
@@ -1,0 +1,84 @@
+package com.exchangediary.member.api;
+
+import com.exchangediary.ApiBaseTest;
+import com.exchangediary.group.domain.GroupRepository;
+import com.exchangediary.group.domain.entity.Group;
+import com.exchangediary.member.domain.enums.GroupRole;
+import com.exchangediary.member.ui.dto.response.AnonymousInfoResponse;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnonymousApiTest extends ApiBaseTest {
+    private static final String URI = "/api/anonymous/info";
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Test
+    void 로그인한_그룹가입한_사용자() {
+        Group group = createGroup();
+        updateSelf(group);
+
+        var body = RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().get(URI)
+                .then().log().all()
+                .extract().as(AnonymousInfoResponse.class);
+
+        assertThat(body.shouldLogin()).isFalse();
+        assertThat(body.groupId()).isEqualTo(group.getId());
+    }
+
+    @Test
+    void 로그인_안한_그룹가입한_사용자() {
+        Group group = createGroup();
+        updateSelf(group);
+
+        var body = RestAssured
+                .given().log().all()
+                .when().get(URI)
+                .then().log().all()
+                .extract().as(AnonymousInfoResponse.class);
+
+        assertThat(body.shouldLogin()).isTrue();
+        assertThat(body.groupId()).isNull();
+    }
+
+    @Test
+    void 로그인한_그룹미가입_사용자() {
+        var body = RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().get(URI)
+                .then().log().all()
+                .extract().as(AnonymousInfoResponse.class);
+
+        assertThat(body.shouldLogin()).isFalse();
+        assertThat(body.groupId()).isNull();
+    }
+
+    @Test
+    void 로그인_안한_그룹미가입_사용자() {
+        var body = RestAssured
+                .given().log().all()
+                .when().get(URI)
+                .then().log().all()
+                .extract().as(AnonymousInfoResponse.class);
+
+        assertThat(body.shouldLogin()).isTrue();
+        assertThat(body.groupId()).isNull();
+    }
+
+    private Group createGroup() {
+        Group group = Group.from("버니즈");
+        return groupRepository.save(group);
+    }
+
+    private void updateSelf(Group group) {
+        member.joinGroup("닉넴", "red", 1, GroupRole.GROUP_LEADER, group);
+        memberRepository.save(member);
+    }
+}

--- a/src/test/java/com/exchangediary/member/service/JwtServiceTest.java
+++ b/src/test/java/com/exchangediary/member/service/JwtServiceTest.java
@@ -29,6 +29,8 @@ public class JwtServiceTest {
         Long memberId = 1L;
         String token = jwtService.generateAccessToken(memberId);
 
-        jwtService.verifyAccessToken(token);
+        String newToken = jwtService.verifyAccessToken(token);
+
+        assertThat(newToken).isNull();
     }
 }


### PR DESCRIPTION
## Work Description
> 익명의 사용자 정보 조회 API 구현

- 로그인 여부와 그룹 가입 여부를 알려주는 익명 사용자 정보 조회 API를 구현했습니다.
- 모든 경우(4가지)에 대해서 테스트를 작성했습니다.
- 로그인 여부 판별에 사용되는 jwt service와 cookie service를 리팩터링했습니다.

## ISSUE
- closed #456


## Screenshot
- 구현한 API 테스트 결과입니다.
<img width="348" alt="Screenshot 2025-02-11 at 7 49 52 PM" src="https://github.com/user-attachments/assets/d2971d96-1754-43f0-91ba-8a9a3f143de0" />


## To Reviewers
- 현재 인터셉터 부분에서 실패하는 테스트가 있는데, #462에서 인터셉터 코드가 다량 변경되었기에 해당 pr 닫힌 후 머지하여 테스트 수정하도록 하겠습니다. 그러니까 얼른 pr 확인 부탁드려요~
- 작성된 [API 명세서](https://www.notion.so/yeeuniii/190d836989fc80f88de9e89b261fa559?pvs=4)에 맞게 구현되었는지 더블체크 부탁드려요!