### PR TITLE
익명 조회 API 오류 해결

### DIFF
--- a/src/main/java/com/exchangediary/global/config/web/WebConfig.java
+++ b/src/main/java/com/exchangediary/global/config/web/WebConfig.java
@@ -34,8 +34,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new JwtAuthenticationInterceptor(jwtService, cookieService, memberQueryService))
-                .addPathPatterns("/groups", "/diaries/**", "/groups/**", "/api/**")
-                .excludePathPatterns("/", "/login", "/api/kakao/callback", "/api/anonymous/info");
+                .addPathPatterns("/login", "/groups/**", "/diaries/**", "/api/**")
+                .excludePathPatterns("/", "/api/kakao/callback", "/api/anonymous/info");
         registry.addInterceptor(new GroupAuthorizationInterceptor(memberQueryService))
                 .addPathPatterns("/groups/**", "/api/groups/*/**")
                 .excludePathPatterns(

--- a/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
+++ b/src/main/java/com/exchangediary/global/config/web/interceptor/JwtAuthenticationInterceptor.java
@@ -41,6 +41,11 @@ public class JwtAuthenticationInterceptor implements HandlerInterceptor {
             response.sendRedirect("/login");
             return false;
         }
+
+        if (request.getRequestURI().equals("/login")) {
+            response.sendRedirect("/");
+            return false;
+        }
         return true;
     }
 

--- a/src/main/java/com/exchangediary/member/ui/ApiKakaoLoginController.java
+++ b/src/main/java/com/exchangediary/member/ui/ApiKakaoLoginController.java
@@ -4,17 +4,16 @@ import com.exchangediary.member.service.CookieService;
 import com.exchangediary.member.service.JwtService;
 import com.exchangediary.member.service.KakaoService;
 import com.exchangediary.member.service.MemberRegistrationService;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/kakao")
 public class ApiKakaoLoginController {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,10 +27,10 @@ spring.jpa.properties.hibernate.globally_quoted_identifiers=true
 kakao.client_id=${KAKAO_CLIENT_ID}
 kakao.redirect_uri=http://localhost:8080${KAKAO_REDIRECT_URI}
 
-# Jwt
+# Jwt (access - 1hour, refresh - 30days)
 security.jwt.secret-key=${JWT_SECRET_KEY}
 security.jwt.access-token.expiration-time=3600000
-security.jwt.refresh-token.expiration-time=2149200000
+security.jwt.refresh-token.expiration-time=259200000
 
 cookie.max-age.millisecond=604800000
 


### PR DESCRIPTION
## Work Description
> 익명 조회 API 오류 해결

- jwt 토큰의 예외 처리가 제대로 되어 있지 않아서 access token이 만료 시 익명 조회 API에서 오류가 발생하여 403 페이지가 뜨는 오류가 있었습니다.
- jwt 서비스 내에서 예외 처리를 추가하여 문제를 해결했습니다.
- 오류를 해결하면서 /login 페이지에 대해서 인터셉터 처리가 정상적으로 되고 있지 않아서 함께 해결해주었습니다.
  - 로그인한 사용자가 /login 페이지 접근 시 시작 페이지로 리다이렉트

## ISSUE
- closed #477 

## To Reviewers
승인되면 머지 후, 재배포 진행하도록 하겠습니다!
hotfix이므로 가급적 빠른 확인 부탁드려요!!
