### PR TITLE
알림 오류 및 익명 정보 조회 API 오류 수정

### DIFF
--- a/src/main/java/com/exchangediary/member/service/JwtService.java
+++ b/src/main/java/com/exchangediary/member/service/JwtService.java
@@ -5,7 +5,6 @@ import com.exchangediary.global.exception.serviceexception.UnauthorizedException
 import com.exchangediary.member.domain.entity.RefreshToken;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -17,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.security.Key;
 import java.util.Date;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -53,15 +53,15 @@ public class JwtService {
                 .compact();
     }
 
-    public String verifyAccessToken(String token) throws UnauthorizedException {
+    public Optional<Long> verifyAccessToken(String token) throws UnauthorizedException {
         try {
             verifyToken(token);
         } catch (ExpiredJwtException exception) {
             Long memberId = Long.valueOf(exception.getClaims().getSubject());
             verifyRefreshToken(memberId);
-            return generateAccessToken(memberId);
+            return Optional.of(memberId);
         }
-        return null;
+        return Optional.empty();
     }
 
     public Long extractMemberId(String token) {

--- a/src/main/java/com/exchangediary/notification/component/NotificationScheduler.java
+++ b/src/main/java/com/exchangediary/notification/component/NotificationScheduler.java
@@ -3,6 +3,7 @@ package com.exchangediary.notification.component;
 import com.exchangediary.notification.service.NotificationService;
 import com.exchangediary.notification.service.NotificationTokenService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +12,8 @@ import org.springframework.stereotype.Component;
 public class NotificationScheduler {
     private final NotificationService notificationService;
     private final NotificationTokenService notificationTokenService;
+    @Value("${fcm.token.expiration-day}")
+    private String fcmTokenExpirationDay;
 
     @Scheduled(cron = "0 0 9,21 * * *")
     public void pushWriteDiaryNotification() {
@@ -19,6 +22,6 @@ public class NotificationScheduler {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void manageTokenFreshness() {
-        notificationTokenService.deleteOldTokens();
+        notificationTokenService.deleteOldTokens(Long.parseLong(fcmTokenExpirationDay));
     }
 }

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
@@ -22,6 +23,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             "WHERE m.orderInGroup = m.group.currentOrder AND d.id is NULL")
     List<String> findTokensNoDiaryToday();
     @Modifying
-    @Query("DELETE FROM Notification n WHERE CURRENT_DATE - CAST(n.createdAt AS DATE) >= 30")
-    void deleteAllIfAMonthOld();
+    @Query("DELETE FROM Notification n WHERE n.createdAt < :localDateTime")
+    void deleteAllByCreatedAtLessThan(LocalDateTime localDateTime);
 }

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -25,4 +25,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query("DELETE FROM Notification n WHERE n.createdAt < :localDateTime")
     void deleteAllByCreatedAtLessThan(LocalDateTime localDateTime);
+    boolean existsByToken(String token);
 }

--- a/src/main/java/com/exchangediary/notification/domain/entity/Notification.java
+++ b/src/main/java/com/exchangediary/notification/domain/entity/Notification.java
@@ -10,6 +10,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,6 +26,12 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @NoArgsConstructor(access = PROTECTED, force = true)
 @AllArgsConstructor(access = PRIVATE)
+@Table(name = "Notification", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "unique_token",
+                columnNames = "token"
+        )
+})
 public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -66,7 +66,7 @@ public class NotificationTokenService {
     }
 
     @Transactional
-    public void deleteOldTokens() {
-        notificationRepository.deleteAllByCreatedAtLessThan(LocalDateTime.now().minusMonths(1));
+    public void deleteOldTokens(long expirationDay) {
+        notificationRepository.deleteAllByCreatedAtLessThan(LocalDateTime.now().minusDays(expirationDay));
     }
 }

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -52,16 +52,17 @@ public class NotificationTokenService {
         return notificationRepository.findTokensNoDiaryToday();
     }
 
+    @Transactional
     public void saveNotificationToken(NotificationTokenRequest notificationTokenRequest, Long memberId) {
         Member member = memberQueryService.findMember(memberId);
-        Notification notification = Notification.builder()
-                .token(notificationTokenRequest.token())
-                .member(member)
-                .build();
+        boolean isDuplicated = notificationRepository.existsByToken(notificationTokenRequest.token());
 
-        try {
+        if (!isDuplicated) {
+            Notification notification = Notification.builder()
+                    .token(notificationTokenRequest.token())
+                    .member(member)
+                    .build();
             notificationRepository.save(notification);
-        } catch (DataIntegrityViolationException ignored) {
         }
     }
 

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -10,6 +10,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,6 +67,6 @@ public class NotificationTokenService {
 
     @Transactional
     public void deleteOldTokens() {
-        notificationRepository.deleteAllIfAMonthOld();
+        notificationRepository.deleteAllByCreatedAtLessThan(LocalDateTime.now().minusMonths(1));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,12 +27,12 @@ spring.jpa.properties.hibernate.globally_quoted_identifiers=true
 kakao.client_id=${KAKAO_CLIENT_ID}
 kakao.redirect_uri=http://localhost:8080${KAKAO_REDIRECT_URI}
 
-# Jwt (access - 1hour, refresh - 30days)
+# Jwt (access - 1hour, refresh - 30days, milliseconds)
 security.jwt.secret-key=${JWT_SECRET_KEY}
 security.jwt.access-token.expiration-time=3600000
 security.jwt.refresh-token.expiration-time=259200000
 
-cookie.max-age.millisecond=604800000
+cookie.max-age.millisecond=259200000
 
 # thymeleaf
 spring.thymeleaf.prefix=classpath:/templates/
@@ -47,6 +47,7 @@ spring.servlet.multipart.max-request-size=10MB
 file.resources.location=${LOCAL_FILE_LOCATION}
 
 # fcm
+fcm.token.expiration-day=30
 fcm.api-key=${FCM_API_KEY}
 fcm.auth-domain=${FCM_AUTH_DOMAIN}
 fcm.project-id=${FCM_PROJECT_ID}

--- a/src/test/java/com/exchangediary/member/service/JwtServiceTest.java
+++ b/src/test/java/com/exchangediary/member/service/JwtServiceTest.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
@@ -29,8 +31,8 @@ public class JwtServiceTest {
         Long memberId = 1L;
         String token = jwtService.generateAccessToken(memberId);
 
-        String newToken = jwtService.verifyAccessToken(token);
+        Optional<Long> result = jwtService.verifyAccessToken(token);
 
-        assertThat(newToken).isNull();
+        assertThat(result.isPresent()).isFalse();
     }
 }

--- a/src/test/java/com/exchangediary/member/service/ReissueJwtTokenTest.java
+++ b/src/test/java/com/exchangediary/member/service/ReissueJwtTokenTest.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
@@ -35,9 +37,8 @@ public class ReissueJwtTokenTest {
         refreshTokenRepository.save(refreshToken);
 
         Thread.sleep(1000);
-        String newToken = jwtService.verifyAccessToken(token);
+        Optional<Long> memberId = jwtService.verifyAccessToken(token);
 
-        Long memberId = jwtService.extractMemberId(newToken);
-        assertThat(memberId).isEqualTo(member.getId());
+        assertThat(memberId.isPresent()).isTrue();
     }
 }

--- a/src/test/java/com/exchangediary/notification/api/NotificationApiTest.java
+++ b/src/test/java/com/exchangediary/notification/api/NotificationApiTest.java
@@ -35,7 +35,32 @@ public class NotificationApiTest extends ApiBaseTest {
     }
 
     @Test
-    void 알림_fcm_토큰_업데이트_성공() {
+    void 동일한_fcm_토큰_저장() {
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(new NotificationTokenRequest("token"))
+                .when().patch("/api/members/notifications/token")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(new NotificationTokenRequest("token"))
+                .when().patch("/api/members/notifications/token")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        List<Notification> notifications = notificationRepository.findByMemberId(member.getId());
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).getToken()).isEqualTo("token");
+    }
+
+    @Test
+    void 알림_fcm_토큰_여러개_저장() {
         RestAssured
                 .given()
                 .cookie("token", token)

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -31,6 +31,7 @@ security.jwt.refresh-token.expiration-time=3600000
 cookie.max-age.millisecond=5400000
 
 # fcm
+fcm.token.expiration-day=30
 fcm.api-key=${FCM_API_KEY}
 fcm.auth-domain=${FCM_AUTH_DOMAIN}
 fcm.project-id=${FCM_PROJECT_ID}


### PR DESCRIPTION
## Work Description
> 알림 오류 및 익명 정보 조회 API 오류 수정

- 익명 정보 조회 API 토큰 갱신이 잘못되는 부분 확인 후 수정하였습니다.
  - jwtservice의 access token을 검증하는 함수에서 access token을 재발급하는 로직을 분리하여, token을 갱신하는 방식으로 수정해주었습니다.
- fcm 토큰 신선도 관리 sql문 오류 해결했습니다.
  - sql에서 날짜를 비교하지 않고, java에서 연산 후 매개변수로 넘겨주어 날짜를 비교해주었습니다.
- 중복된 fcm token 저장 시도 시, unique 제약 조건으로 인해 DB에서 오류가 발생하였습니다.
예상할 수 있는 예외로 이 경우 DB에까지 요청이 전달되지 않도록 변경해주었습니다.
  - 요청받은 토큰이 DB에 존재하는지 확인 후, 중복되지 않는 경우에만 DB에 저장해주었습니다.

## ISSUE
- closed #482

## To Reviewers
익명 정보 조회 API에서 재발급된 access token 처리에서 계속 이슈가 발생하여서 이 부분 코드 제가 몇번 확인하였는데, 혹시 모르니 다같이 더블체크 한 번만 부탁드려요!!

## Reference
[JPQL 로 시간 조건걸기](https://gist.github.com/jjangga0214/2dc6b788b8db74aadffb1625d6e7f6de)

