### PR TITLE
도커 컴포즈 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ out/
 /log
 buddies-spring-firebase-adminsdk-fadag-ba724eb696.json
 env.properties
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -48,3 +48,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+bootJar {
+    archiveFileName = "${rootProject.name}.jar"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - '8080:8080'
     volumes:
       - './build/libs/spring.jar:/app/spring.jar'
-      - 'spring-log:/app/log'
+      - './log:/app/log'
     command: java -Xms512m -Xmx512m -jar spring.jar
 
   database:
@@ -29,6 +29,4 @@ services:
 
 volumes:
   spring-db:
-    external: true
-  spring-log:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       - './build/libs/spring.jar:/app/spring.jar'
       - './log:/app/log'
       - '../upload:/app/upload'
-    command: java -Xms512m -Xmx512m -jar spring.jar
+    environment:
+      - TZ=Asia/Seoul
+    command: java -Duser.timezone=Asia/Seoul -Xms512m -Xmx512m -jar spring.jar
 
   database:
     image: postgres:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   application:
     image: openjdk:21
     container_name: spring-app
+    working_dir: /app
     restart: always
     depends_on:
       - database
@@ -10,21 +11,24 @@ services:
       - '8080:8080'
     volumes:
       - './build/libs/spring.jar:/app/spring.jar'
-    command: java -jar /app/spring.jar
+      - 'spring-log:/app/log'
+    command: java -Xms512m -Xmx512m -jar spring.jar
 
   database:
     image: postgres:latest
-    container_name: spring-database
+    container_name: spring-db
     restart: always
     ports:
       - '5432:5432'
     volumes:
-      - spring:/var/lib/postgresql/data  
+      - spring-db:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
 
 volumes:
-  spring:
+  spring-db:
+    external: true
+  spring-log:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - './build/libs/spring.jar:/app/spring.jar'
       - './log:/app/log'
+      - '../upload:/app/upload'
     command: java -Xms512m -Xmx512m -jar spring.jar
 
   database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  application:
+    image: openjdk:21
+    container_name: spring-app
+    restart: always
+    depends_on:
+      - database
+    ports:
+      - '8080:8080'
+    volumes:
+      - './build/libs/spring.jar:/app/spring.jar'
+    command: java -jar /app/spring.jar
+
+  database:
+    image: postgres:latest
+    container_name: spring-database
+    restart: always
+    ports:
+      - '5432:5432'
+    volumes:
+      - spring:/var/lib/postgresql/data  
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+
+volumes:
+  spring:
+    external: true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'exchangediary'
+rootProject.name = 'spring'

--- a/src/main/java/com/exchangediary/member/service/CookieService.java
+++ b/src/main/java/com/exchangediary/member/service/CookieService.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
 
 @Service
 public class CookieService {
-    @Value("${cookie.max-age.millisecond}")
-    private int maxAgeInMilliseconds;
+    @Value("${cookie.max-age.second}")
+    private int maxAgeInSeconds;
 
     public void addCookie(String name, String value, HttpServletResponse response) {
         Cookie cookie = createCookie(name, value);
@@ -21,7 +21,7 @@ public class CookieService {
         Cookie cookie = new Cookie(name, value);
         cookie.setHttpOnly(true);
         cookie.setPath("/");
-        cookie.setMaxAge(maxAgeInMilliseconds / 1000);
+        cookie.setMaxAge(maxAgeInSeconds);
         return cookie;
     }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -2,4 +2,4 @@ server.port=8888
 
 kakao.redirect_uri=http://211.45.162.60:8889${KAKAO_REDIRECT_URI}
 
-file.resources.location=/root/dev/upload/
+file.resources.location=/app/upload/

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,3 +1,3 @@
 kakao.redirect_uri=https://buddies-spring.site${KAKAO_REDIRECT_URI}
 
-file.resources.location=/root/upload/
+file.resources.location=/app/upload/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,7 +32,7 @@ security.jwt.secret-key=${JWT_SECRET_KEY}
 security.jwt.access-token.expiration-time=3600000
 security.jwt.refresh-token.expiration-time=2592000000
 
-cookie.max-age.millisecond=2592000000
+cookie.max-age.second=2592000
 
 # thymeleaf
 spring.thymeleaf.prefix=classpath:/templates/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,9 +30,9 @@ kakao.redirect_uri=http://localhost:8080${KAKAO_REDIRECT_URI}
 # Jwt (access - 1hour, refresh - 30days, milliseconds)
 security.jwt.secret-key=${JWT_SECRET_KEY}
 security.jwt.access-token.expiration-time=3600000
-security.jwt.refresh-token.expiration-time=259200000
+security.jwt.refresh-token.expiration-time=2592000000
 
-cookie.max-age.millisecond=259200000
+cookie.max-age.millisecond=2592000000
 
 # thymeleaf
 spring.thymeleaf.prefix=classpath:/templates/

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -28,7 +28,7 @@ security.jwt.secret-key=${JWT_SECRET_KEY}
 security.jwt.access-token.expiration-time=3600000
 security.jwt.refresh-token.expiration-time=3600000
 
-cookie.max-age.millisecond=5400000
+cookie.max-age.second=2592000
 
 # fcm
 fcm.token.expiration-day=30


### PR DESCRIPTION
## Work Description
> 도커 컴포즈 추가

- postgresql 데이터베이스와 spring 서버를 도커 컴포즈로 함께 관리하여 배포할 수 있게끔 yml 파일 작성했습니다.
- 작업 중 쿠키와 refresh token의 시간이 잘못 설정되어있는 것을 발견하여 함께 수정해주었습니다.

## ISSUE
- closed #485

## To Reviewers
- nginx 서버는 당장 서비스로 추가할 필요가 없다고 생각이 들어 추가하지 않았습니다. 추후 필요하다고 판단되면 작업하도록 하겠습니다.
- 멀티 스테이징으로 도커에서 빌드와 실행을 진행하는 것보다, 로컬에서 빌드 후 jar 파일을 통해 도커 컨테이너에서 실행만 시키도록 백엔드 애플리케이션이 동작하도록 설계했습니다. 가볍다는 이점이 있고, 추후 github actions 도입을 고려했을 때 이 방향이 확장성이 좋을 것 같아서 jar 파일만 마운팅하는 방식을 채택했습니다. 
- 테스트를 위해 현재 실행 중인 서버를 도커 컴포즈로 실행 중이고, 며칠간 잘 동작되는 것 확인했습니다.