### PR TITLE
알림 활성화 속성 추가 및 API 구현

### DIFF
--- a/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
+++ b/src/main/java/com/exchangediary/diary/service/DiaryWriteService.java
@@ -2,6 +2,7 @@ package com.exchangediary.diary.service;
 
 import com.exchangediary.diary.domain.DiaryContentRepository;
 import com.exchangediary.diary.domain.DiaryRepository;
+import com.exchangediary.diary.ui.dto.notification.DiaryWriteNotification;
 import com.exchangediary.diary.ui.dto.request.DiaryContentRequest;
 import com.exchangediary.diary.domain.entity.Diary;
 import com.exchangediary.diary.domain.entity.DiaryContent;
@@ -38,7 +39,7 @@ public class DiaryWriteService {
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
 
-    public Long writeDiary(DiaryRequest diaryRequest, MultipartFile file, String groupId, Long memberId) {
+    public DiaryWriteNotification writeDiary(DiaryRequest diaryRequest, MultipartFile file, String groupId, Long memberId) {
         GroupMember writer = groupMemberQueryService.findGroupMemberByMemberId(memberId);
         Group group = groupQueryService.findGroup(groupId);
 
@@ -53,7 +54,7 @@ public class DiaryWriteService {
             updateGroupCurrentOrder(group);
             updateViewableDiaryDate(writer, group);
 
-            return savedDiary.getId();
+            return DiaryWriteNotification.from(savedDiary);
         } catch (IOException e) {
             throw new FailedImageUploadException(ErrorCode.FAILED_UPLOAD_IMAGE, "", file.getOriginalFilename());
         }

--- a/src/main/java/com/exchangediary/diary/ui/ApiDiaryController.java
+++ b/src/main/java/com/exchangediary/diary/ui/ApiDiaryController.java
@@ -42,7 +42,7 @@ public class ApiDiaryController {
         notificationService.pushToAllGroupMembersExceptMember(
                 groupId,
                 memberId,
-                String.format("%s(이)가 %s 일기를 작성했어요.", diary.writerNickname(), diary.createdAt())
+                String.format("%s(이)가 일기를 작성했어요.", diary.writerNickname())
         );
         notificationService.pushDiaryOrderNotification(groupId);
 

--- a/src/main/java/com/exchangediary/diary/ui/ApiDiaryController.java
+++ b/src/main/java/com/exchangediary/diary/ui/ApiDiaryController.java
@@ -2,6 +2,7 @@ package com.exchangediary.diary.ui;
 
 import com.exchangediary.diary.service.DiaryWriteService;
 import com.exchangediary.diary.service.DiaryQueryService;
+import com.exchangediary.diary.ui.dto.notification.DiaryWriteNotification;
 import com.exchangediary.diary.ui.dto.request.DiaryRequest;
 import com.exchangediary.diary.ui.dto.response.DiaryResponse;
 import com.exchangediary.diary.ui.dto.response.TodayDiaryStatusResponse;
@@ -36,12 +37,18 @@ public class ApiDiaryController {
             @PathVariable String groupId,
             @RequestAttribute Long memberId
     ) {
-        Long diaryId = diaryWriteService.writeDiary(diaryRequest, file, groupId, memberId);
-        notificationService.pushToAllGroupMembersExceptMember(groupId, memberId, "친구가 일기를 작성했어요!");
+        DiaryWriteNotification diary = diaryWriteService.writeDiary(diaryRequest, file, groupId, memberId);
+
+        notificationService.pushToAllGroupMembersExceptMember(
+                groupId,
+                memberId,
+                String.format("%s(이)가 %s 일기를 작성했어요.", diary.writerNickname(), diary.createdAt())
+        );
         notificationService.pushDiaryOrderNotification(groupId);
+
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .header("Content-Location", "/groups/" + groupId + "/diaries/" + diaryId)
+                .header("Content-Location", "/groups/" + groupId + "/diaries/" + diary.diaryId())
                 .build();
     }
 

--- a/src/main/java/com/exchangediary/diary/ui/dto/notification/DiaryWriteNotification.java
+++ b/src/main/java/com/exchangediary/diary/ui/dto/notification/DiaryWriteNotification.java
@@ -1,0 +1,21 @@
+package com.exchangediary.diary.ui.dto.notification;
+
+import com.exchangediary.diary.domain.entity.Diary;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record DiaryWriteNotification(
+        Long diaryId,
+        String writerNickname,
+        LocalDate createdAt
+) {
+    public static DiaryWriteNotification from(Diary diary) {
+        return DiaryWriteNotification.builder()
+                .diaryId(diary.getId())
+                .writerNickname(diary.getGroupMember().getNickname())
+                .createdAt(diary.getCreatedAt().toLocalDate())
+                .build();
+    }
+}

--- a/src/main/java/com/exchangediary/diary/ui/dto/notification/DiaryWriteNotification.java
+++ b/src/main/java/com/exchangediary/diary/ui/dto/notification/DiaryWriteNotification.java
@@ -3,19 +3,15 @@ package com.exchangediary.diary.ui.dto.notification;
 import com.exchangediary.diary.domain.entity.Diary;
 import lombok.Builder;
 
-import java.time.LocalDate;
-
 @Builder
 public record DiaryWriteNotification(
         Long diaryId,
-        String writerNickname,
-        LocalDate createdAt
+        String writerNickname
 ) {
     public static DiaryWriteNotification from(Diary diary) {
         return DiaryWriteNotification.builder()
                 .diaryId(diary.getId())
                 .writerNickname(diary.getGroupMember().getNickname())
-                .createdAt(diary.getCreatedAt().toLocalDate())
                 .build();
     }
 }

--- a/src/main/java/com/exchangediary/group/service/GroupCreateJoinService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupCreateJoinService.java
@@ -5,6 +5,7 @@ import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.domain.entity.GroupMember;
 import com.exchangediary.group.domain.enums.GroupRole;
+import com.exchangediary.group.ui.dto.notification.GroupJoinNotification;
 import com.exchangediary.group.ui.dto.request.GroupCreateRequest;
 import com.exchangediary.group.ui.dto.request.GroupJoinRequest;
 import com.exchangediary.group.ui.dto.response.GroupCreateResponse;
@@ -33,7 +34,7 @@ public class GroupCreateJoinService {
         return GroupCreateResponse.from(savedGroup);
     }
 
-    public void joinGroup(String groupId, Long memberId, GroupJoinRequest request) {
+    public GroupJoinNotification joinGroup(String groupId, Long memberId, GroupJoinRequest request) {
         Group group = groupQueryService.findGroup(groupId);
         Member member = memberQueryService.findMember(memberId);
 
@@ -41,10 +42,11 @@ public class GroupCreateJoinService {
         groupValidationService.checkNicknameDuplicate(group.getGroupMembers(), request.nickname());
         groupValidationService.checkProfileDuplicate(group.getGroupMembers(), request.profileImage());
 
-        createGroupMember(request.nickname(), request.profileImage(), GroupRole.GROUP_MEMBER, group, member);
+        GroupMember joinMember = createGroupMember(request.nickname(), request.profileImage(), GroupRole.GROUP_MEMBER, group, member);
+        return GroupJoinNotification.from(joinMember);
     }
 
-    private void createGroupMember(String nickname, String profileImage, GroupRole groupRole, Group group, Member member) {
+    private GroupMember createGroupMember(String nickname, String profileImage, GroupRole groupRole, Group group, Member member) {
         GroupMember groupMember = GroupMember.of(
                 nickname,
                 profileImage,
@@ -53,7 +55,7 @@ public class GroupCreateJoinService {
                 group,
                 member
         );
-        groupMemberRepository.save(groupMember);
         group.joinMember();
+        return groupMemberRepository.save(groupMember);
     }
 }

--- a/src/main/java/com/exchangediary/group/service/GroupLeaveService.java
+++ b/src/main/java/com/exchangediary/group/service/GroupLeaveService.java
@@ -8,6 +8,7 @@ import com.exchangediary.group.domain.GroupRepository;
 import com.exchangediary.group.domain.entity.Group;
 import com.exchangediary.group.domain.entity.GroupMember;
 import com.exchangediary.group.domain.enums.GroupRole;
+import com.exchangediary.group.ui.dto.notification.GroupLeaveNotification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +23,7 @@ public class GroupLeaveService {
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
 
-    public void leaveGroup(String groupId, Long memberId) {
+    public GroupLeaveNotification leaveGroup(String groupId, Long memberId) {
         Group group = groupQueryService.findGroup(groupId);
         GroupMember leaveMember = groupMemberQueryService.findGroupMemberByMemberId(memberId);
 
@@ -33,6 +34,7 @@ public class GroupLeaveService {
         groupMemberRepository.flush();
 
         updateGroupAfterMemberLeave(group, leaveMember.getOrderInGroup());
+        return GroupLeaveNotification.from(leaveMember);
     }
 
     private void forbidGroupLeaderLeave(GroupMember groupMember, int memberCount) {

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupController.java
@@ -4,6 +4,8 @@ import com.exchangediary.group.service.GroupLeaveService;
 import com.exchangediary.group.service.GroupMemberQueryService;
 import com.exchangediary.group.service.GroupQueryService;
 import com.exchangediary.group.service.GroupCreateJoinService;
+import com.exchangediary.group.ui.dto.notification.GroupJoinNotification;
+import com.exchangediary.group.ui.dto.notification.GroupLeaveNotification;
 import com.exchangediary.group.ui.dto.request.GroupCodeRequest;
 import com.exchangediary.group.ui.dto.request.GroupJoinRequest;
 import com.exchangediary.group.ui.dto.request.GroupCreateRequest;
@@ -88,8 +90,12 @@ public class ApiGroupController {
             @RequestAttribute Long memberId,
             @RequestBody @Valid GroupJoinRequest request
             ) {
-        groupCreateJoinService.joinGroup(groupId, memberId, request);
-        notificationService.pushToAllGroupMembersExceptMember(groupId, memberId, "새로운 친구가 들어왔어요!");
+        GroupJoinNotification notification = groupCreateJoinService.joinGroup(groupId, memberId, request);
+        notificationService.pushToAllGroupMembersExceptMember(
+                groupId,
+                memberId,
+                String.format("새로운 친구 %s(이)가 들어왔어요.", notification.joinMemberNickname())
+        );
         return ResponseEntity
                 .ok()
                 .build();
@@ -111,8 +117,12 @@ public class ApiGroupController {
             @PathVariable String groupId,
             @RequestAttribute Long memberId
     ) {
-        groupLeaveService.leaveGroup(groupId, memberId);
-        notificationService.pushToAllGroupMembersExceptMember(groupId, memberId, "친구가 그룹에서 나갔어요!");
+        GroupLeaveNotification notification = groupLeaveService.leaveGroup(groupId, memberId);
+        notificationService.pushToAllGroupMembersExceptMember(
+                groupId,
+                memberId,
+                String.format("%s(이)가 그룹에서 나갔어요.", notification.leaveMemberNickname())
+        );
         return ResponseEntity
                 .ok()
                 .build();

--- a/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
+++ b/src/main/java/com/exchangediary/group/ui/ApiGroupLeaderController.java
@@ -1,6 +1,9 @@
 package com.exchangediary.group.ui;
 
 import com.exchangediary.group.service.GroupLeaderService;
+import com.exchangediary.group.ui.dto.notification.GroupLeaderHandOverNotification;
+import com.exchangediary.group.ui.dto.notification.GroupLeaderKickOutNotification;
+import com.exchangediary.group.ui.dto.notification.GroupLeaderSkipDiaryNotification;
 import com.exchangediary.group.ui.dto.request.GroupKickOutRequest;
 import com.exchangediary.group.ui.dto.request.GroupLeaderHandOverRequest;
 import com.exchangediary.notification.service.NotificationService;
@@ -26,9 +29,15 @@ public class ApiGroupLeaderController {
             @RequestAttribute Long memberId,
             @RequestBody GroupLeaderHandOverRequest request
     ) {
-        long newLeaderId = groupLeaderService.handOverGroupLeader(groupId, memberId, request);
-        notificationService.pushToAllGroupMembersExceptMemberAndLeader(groupId, newLeaderId, "방장이 다른 친구에게 방장 역할을 넘겨줬어요!");
-        notificationService.pushNotification(newLeaderId, "방장이 나에게 방장 역할을 넘겨줬어요!");
+        GroupLeaderHandOverNotification notification = groupLeaderService.handOverGroupLeader(groupId, memberId, request);
+
+        notificationService.pushToAllGroupMembersExceptMemberAndLeader(
+                groupId,
+                notification.oldLeaderId(),
+                String.format("%s(이)가 새로운 방장이 되었습니다.", notification.newLeaderNickname())
+        );
+        notificationService.pushNotification(notification.newLeaderId(), "방장이 되었습니다. 방장 권한을 실행해보세요!");
+
         return ResponseEntity
                 .ok()
                 .build();
@@ -36,9 +45,11 @@ public class ApiGroupLeaderController {
 
     @PatchMapping("/skip-order")
     public ResponseEntity<Void> skipDiaryOrder(@PathVariable String groupId) {
-        long skipDiaryMemberId = groupLeaderService.skipDiaryOrder(groupId);
-        notificationService.pushNotification(skipDiaryMemberId, "방장이 일기 순서를 건너뛰었어요.\n다음 순서를 기다려주세요!");
+        GroupLeaderSkipDiaryNotification notification = groupLeaderService.skipDiaryOrder(groupId);
+
+        notificationService.pushNotification(notification.skipDiaryMemberId(), "방장이 일기 순서를 건너뛰었어요.\n다음 순서를 기다려주세요!");
         notificationService.pushDiaryOrderNotification(groupId);
+
         return ResponseEntity
                 .ok()
                 .build();
@@ -49,9 +60,15 @@ public class ApiGroupLeaderController {
             @PathVariable String groupId,
             @RequestBody GroupKickOutRequest request
     ) {
-        long kickOutMemberId = groupLeaderService.kickOutMember(groupId, request);
-        notificationService.pushToAllGroupMembersExceptMemberAndLeader(groupId, kickOutMemberId, "방장이 친구를 그룹에서 내보냈어요!");
-        notificationService.pushNotification(kickOutMemberId, "앗, 그룹에서 내보내졌어요.\n다른 스프링에서 일기 쓰기를 시작해요!");
+        GroupLeaderKickOutNotification notification = groupLeaderService.kickOutMember(groupId, request);
+
+        notificationService.pushToAllGroupMembersExceptMemberAndLeader(
+                groupId,
+                notification.kickOutMemberId(),
+                String.format("방장이 %s(이)를 그룹에서 내보냈어요!", notification.kickOutMemberNickname())
+        );
+        notificationService.pushNotification(notification.kickOutMemberId(), "앗, 그룹에서 내보내졌어요.\n다시 스프링을 시작해볼까요?");
+
         return ResponseEntity
                 .ok()
                 .build();

--- a/src/main/java/com/exchangediary/group/ui/dto/notification/GroupJoinNotification.java
+++ b/src/main/java/com/exchangediary/group/ui/dto/notification/GroupJoinNotification.java
@@ -1,0 +1,15 @@
+package com.exchangediary.group.ui.dto.notification;
+
+import com.exchangediary.group.domain.entity.GroupMember;
+import lombok.Builder;
+
+@Builder
+public record GroupJoinNotification(
+        String joinMemberNickname
+) {
+    public static GroupJoinNotification from(GroupMember joinMember) {
+        return GroupJoinNotification.builder()
+                .joinMemberNickname(joinMember.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/exchangediary/group/ui/dto/notification/GroupLeaderHandOverNotification.java
+++ b/src/main/java/com/exchangediary/group/ui/dto/notification/GroupLeaderHandOverNotification.java
@@ -1,0 +1,19 @@
+package com.exchangediary.group.ui.dto.notification;
+
+import com.exchangediary.group.domain.entity.GroupMember;
+import lombok.Builder;
+
+@Builder
+public record GroupLeaderHandOverNotification(
+        Long oldLeaderId,
+        Long newLeaderId,
+        String newLeaderNickname
+) {
+    public static GroupLeaderHandOverNotification of(GroupMember oldLeader, GroupMember newLeader) {
+        return GroupLeaderHandOverNotification.builder()
+                .oldLeaderId(oldLeader.getMember().getId())
+                .newLeaderId(newLeader.getMember().getId())
+                .newLeaderNickname(newLeader.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/exchangediary/group/ui/dto/notification/GroupLeaderKickOutNotification.java
+++ b/src/main/java/com/exchangediary/group/ui/dto/notification/GroupLeaderKickOutNotification.java
@@ -1,0 +1,17 @@
+package com.exchangediary.group.ui.dto.notification;
+
+import com.exchangediary.group.domain.entity.GroupMember;
+import lombok.Builder;
+
+@Builder
+public record GroupLeaderKickOutNotification(
+        Long kickOutMemberId,
+        String kickOutMemberNickname
+) {
+    public static GroupLeaderKickOutNotification from(GroupMember kickOutMember) {
+        return GroupLeaderKickOutNotification.builder()
+                .kickOutMemberId(kickOutMember.getMember().getId())
+                .kickOutMemberNickname(kickOutMember.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/exchangediary/group/ui/dto/notification/GroupLeaderSkipDiaryNotification.java
+++ b/src/main/java/com/exchangediary/group/ui/dto/notification/GroupLeaderSkipDiaryNotification.java
@@ -1,0 +1,15 @@
+package com.exchangediary.group.ui.dto.notification;
+
+import com.exchangediary.group.domain.entity.GroupMember;
+import lombok.Builder;
+
+@Builder
+public record GroupLeaderSkipDiaryNotification(
+        Long skipDiaryMemberId
+) {
+    public static GroupLeaderSkipDiaryNotification from(GroupMember skipMember) {
+        return GroupLeaderSkipDiaryNotification.builder()
+                .skipDiaryMemberId(skipMember.getMember().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/exchangediary/group/ui/dto/notification/GroupLeaveNotification.java
+++ b/src/main/java/com/exchangediary/group/ui/dto/notification/GroupLeaveNotification.java
@@ -1,0 +1,15 @@
+package com.exchangediary.group.ui.dto.notification;
+
+import com.exchangediary.group.domain.entity.GroupMember;
+import lombok.Builder;
+
+@Builder
+public record GroupLeaveNotification(
+        String leaveMemberNickname
+) {
+    public static GroupLeaveNotification from(GroupMember leaveMember) {
+        return GroupLeaveNotification.builder()
+                .leaveMemberNickname(leaveMember.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/exchangediary/member/domain/MemberRepository.java
+++ b/src/main/java/com/exchangediary/member/domain/MemberRepository.java
@@ -10,7 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByKakaoId(Long kakaoId);
 
     @Query("""
-        SELECT m.on_notification
+        SELECT m.onNotification
         FROM Member m
         WHERE m.id = :id
     """)

--- a/src/main/java/com/exchangediary/member/domain/MemberRepository.java
+++ b/src/main/java/com/exchangediary/member/domain/MemberRepository.java
@@ -2,9 +2,17 @@ package com.exchangediary.member.domain;
 
 import com.exchangediary.member.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByKakaoId(Long kakaoId);
+
+    @Query("""
+        SELECT m.on_notification
+        FROM Member m
+        WHERE m.id = :id
+    """)
+    Optional<Boolean> findOnNotificationById(Long id);
 }

--- a/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -34,4 +34,8 @@ public class Member extends BaseEntity {
                 .onNotification(true)
                 .build();
     }
+
+    public void toggleNotification() {
+        this.onNotification = !this.onNotification;
+    }
 }

--- a/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -26,12 +26,12 @@ public class Member extends BaseEntity {
     @NotNull
     private final Long kakaoId;
     @NotNull
-    private Boolean on_notification;
+    private Boolean onNotification;
 
     public static Member from(Long kakaoId) {
         return Member.builder()
                 .kakaoId(kakaoId)
-                .on_notification(true)
+                .onNotification(true)
                 .build();
     }
 }

--- a/src/main/java/com/exchangediary/member/domain/entity/Member.java
+++ b/src/main/java/com/exchangediary/member/domain/entity/Member.java
@@ -25,10 +25,13 @@ public class Member extends BaseEntity {
     private Long id;
     @NotNull
     private final Long kakaoId;
+    @NotNull
+    private Boolean on_notification;
 
     public static Member from(Long kakaoId) {
         return Member.builder()
                 .kakaoId(kakaoId)
+                .on_notification(true)
                 .build();
     }
 }

--- a/src/main/java/com/exchangediary/member/service/MemberQueryService.java
+++ b/src/main/java/com/exchangediary/member/service/MemberQueryService.java
@@ -4,6 +4,7 @@ import com.exchangediary.global.exception.ErrorCode;
 import com.exchangediary.global.exception.serviceexception.NotFoundException;
 import com.exchangediary.member.domain.MemberRepository;
 import com.exchangediary.member.domain.entity.Member;
+import com.exchangediary.member.ui.dto.response.MemberNotificationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,5 +26,15 @@ public class MemberQueryService {
 
     public boolean existMember(Long memberId) {
         return memberRepository.existsById(memberId);
+    }
+
+    public MemberNotificationResponse getOnNotification(Long memberId) {
+        boolean onNotification = memberRepository.findOnNotificationById(memberId)
+                .orElseThrow(() -> new NotFoundException(
+                        ErrorCode.MEMBER_NOT_FOUND,
+                        "",
+                        String.valueOf(memberId)
+                ));
+        return new MemberNotificationResponse(onNotification);
     }
 }

--- a/src/main/java/com/exchangediary/member/service/MemberUpdateService.java
+++ b/src/main/java/com/exchangediary/member/service/MemberUpdateService.java
@@ -1,0 +1,18 @@
+package com.exchangediary.member.service;
+
+import com.exchangediary.member.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberUpdateService {
+    private final MemberQueryService memberQueryService;
+
+    public void changeOnNotification(Long memberId) {
+        Member member = memberQueryService.findMember(memberId);
+        member.toggleNotification();
+    }
+}

--- a/src/main/java/com/exchangediary/member/ui/ApiMemberController.java
+++ b/src/main/java/com/exchangediary/member/ui/ApiMemberController.java
@@ -1,0 +1,24 @@
+package com.exchangediary.member.ui;
+
+import com.exchangediary.member.service.MemberQueryService;
+import com.exchangediary.member.ui.dto.response.MemberNotificationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+public class ApiMemberController {
+    private final MemberQueryService memberQueryService;
+
+    @GetMapping("/notification")
+    public ResponseEntity<MemberNotificationResponse> getMemberNotificationOn(@RequestAttribute Long memberId) {
+        MemberNotificationResponse body = memberQueryService.getOnNotification(memberId);
+        return ResponseEntity
+                .ok(body);
+    }
+}

--- a/src/main/java/com/exchangediary/member/ui/ApiMemberController.java
+++ b/src/main/java/com/exchangediary/member/ui/ApiMemberController.java
@@ -1,10 +1,12 @@
 package com.exchangediary.member.ui;
 
 import com.exchangediary.member.service.MemberQueryService;
+import com.exchangediary.member.service.MemberUpdateService;
 import com.exchangediary.member.ui.dto.response.MemberNotificationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,11 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/member")
 public class ApiMemberController {
     private final MemberQueryService memberQueryService;
+    private final MemberUpdateService memberUpdateService;
 
     @GetMapping("/notification")
     public ResponseEntity<MemberNotificationResponse> getMemberNotificationOn(@RequestAttribute Long memberId) {
         MemberNotificationResponse body = memberQueryService.getOnNotification(memberId);
         return ResponseEntity
                 .ok(body);
+    }
+
+    @PatchMapping("/notification")
+    public ResponseEntity<MemberNotificationResponse> changeMemberNotificationOn(@RequestAttribute Long memberId) {
+        memberUpdateService.changeOnNotification(memberId);
+        return ResponseEntity
+                .ok()
+                .build();
     }
 }

--- a/src/main/java/com/exchangediary/member/ui/dto/response/MemberNotificationResponse.java
+++ b/src/main/java/com/exchangediary/member/ui/dto/response/MemberNotificationResponse.java
@@ -1,0 +1,6 @@
+package com.exchangediary.member.ui.dto.response;
+
+public record MemberNotificationResponse(
+        Boolean onNotification
+) {
+}

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -9,8 +9,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findAllByMemberId(Long memberId);
     boolean existsByToken(String token);
+
+    @Query("""
+        SELECT n.token
+        FROM Notification n
+        WHERE n.member.onNotification = true
+    """)
+    List<String> findTokensByMemberId(Long memberId);
 
     @Query("""
         SELECT n.token
@@ -20,6 +26,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             ON gm.member = m
         WHERE gm.group.id = :groupId
             AND m.id <> :memberId
+            AND m.onNotification = true
     """)
     List<String> findTokensByGroupIdAndExcludeMemberId(String groupId, Long memberId);
 
@@ -32,6 +39,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         WHERE gm.group.id = :groupId
             AND m.id <> :memberId
             AND gm.groupRole <> 'GROUP_LEADER'
+            AND m.onNotification = true
     """)
     List<String> findTokensByGroupIdAndExcludeMemberIdAndLeader(String groupId, Long memberId);
 
@@ -43,6 +51,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             ON gm.member = m
         WHERE gm.group.id = :groupId
             AND gm.orderInGroup = gm.group.currentOrder
+            AND m.onNotification = true
     """)
     List<String> findTokensByGroupIdAndCurrentOrder(String groupId);
 
@@ -57,6 +66,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             AND CAST(d.createdAt AS DATE) = CURRENT_DATE
         WHERE gm.orderInGroup = gm.group.currentOrder
             AND d.id IS NULL
+            AND m.onNotification = true
     """)
     List<String> findTokensByMembersWithoutDiaryToday();
 

--- a/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/exchangediary/notification/domain/NotificationRepository.java
@@ -14,7 +14,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("""
         SELECT n.token
         FROM Notification n
-        WHERE n.member.onNotification = true
+        WHERE n.member.id = :memberId
+            AND n.member.onNotification = true
     """)
     List<String> findTokensByMemberId(Long memberId);
 

--- a/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
+++ b/src/main/java/com/exchangediary/notification/service/NotificationTokenService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -21,30 +20,20 @@ public class NotificationTokenService {
     private final MemberQueryService memberQueryService;
 
     public List<String> findTokensByMember(Long memberId) {
-        List<Notification> notifications = notificationRepository.findAllByMemberId(memberId);
-
-        if (notifications.isEmpty()) {
-            return new ArrayList<>();
-        }
-        return notifications.stream()
-                .map(Notification::getToken)
-                .toList();
+        return notificationRepository.findTokensByMemberId(memberId);
     }
 
     public List<String> findTokensByCurrentOrderInGroup(String groupId) {
         return notificationRepository.findTokensByGroupIdAndCurrentOrder(groupId);
     }
 
-
     public List<String> findTokensByGroupAndExcludeMember(String groupId, Long memberId) {
         return notificationRepository.findTokensByGroupIdAndExcludeMemberId(groupId, memberId);
     }
 
-
     public List<String> findTokensByGroupAndExcludeMemberAndLeader(String groupId, Long memberId) {
         return notificationRepository.findTokensByGroupIdAndExcludeMemberIdAndLeader(groupId, memberId);
     }
-
 
     public List<String> findTokensWithoutDiaryToday() {
         return notificationRepository.findTokensByMembersWithoutDiaryToday();

--- a/src/main/resources/db/migration/V4.3__add_notifcation_on_column.sql
+++ b/src/main/resources/db/migration/V4.3__add_notifcation_on_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member ADD COLUMN on_notification BOOLEAN NOT NULL DEFAULT true

--- a/src/test/java/com/exchangediary/member/api/OnNotificationApiTest.java
+++ b/src/test/java/com/exchangediary/member/api/OnNotificationApiTest.java
@@ -1,0 +1,28 @@
+package com.exchangediary.member.api;
+
+import com.exchangediary.ApiBaseTest;
+import com.exchangediary.member.ui.dto.response.MemberNotificationResponse;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OnNotificationApiTest extends ApiBaseTest {
+    private static final String URI = "/api/member/notification";
+
+    @Test
+    @DisplayName("사용자의 알림 활성화 여부를 조회한다.")
+    void When_MembersOnNotificationIsTrue() {
+        MemberNotificationResponse body = RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().get(URI)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(MemberNotificationResponse.class);
+
+        assertThat(body.onNotification()).isTrue();
+    }
+}

--- a/src/test/java/com/exchangediary/member/api/OnNotificationApiTest.java
+++ b/src/test/java/com/exchangediary/member/api/OnNotificationApiTest.java
@@ -1,6 +1,7 @@
 package com.exchangediary.member.api;
 
 import com.exchangediary.ApiBaseTest;
+import com.exchangediary.member.domain.entity.Member;
 import com.exchangediary.member.ui.dto.response.MemberNotificationResponse;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.DisplayName;
@@ -24,5 +25,19 @@ public class OnNotificationApiTest extends ApiBaseTest {
                 .extract().as(MemberNotificationResponse.class);
 
         assertThat(body.onNotification()).isTrue();
+    }
+
+    @Test
+    @DisplayName("사용자의 알림 활성화를 끈다.")
+    void When_MembersOnNotificationIsTrue_Expect_ChangeOnNotificationIsFalse() {
+        RestAssured
+                .given().log().all()
+                .cookie("token", token)
+                .when().patch(URI)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        Member updatedMember = memberRepository.findById(member.getId()).get();
+        assertThat(updatedMember.getOnNotification()).isFalse();
     }
 }

--- a/src/test/java/com/exchangediary/notification/api/NotificationApiTest.java
+++ b/src/test/java/com/exchangediary/notification/api/NotificationApiTest.java
@@ -2,7 +2,6 @@ package com.exchangediary.notification.api;
 
 import com.exchangediary.ApiBaseTest;
 import com.exchangediary.notification.domain.NotificationRepository;
-import com.exchangediary.notification.domain.entity.Notification;
 import com.exchangediary.notification.ui.dto.request.NotificationTokenRequest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -34,9 +33,9 @@ public class NotificationApiTest extends ApiBaseTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 
-        List<Notification> notifications = notificationRepository.findAllByMemberId(member.getId());
+        List<String> notifications = notificationRepository.findTokensByMemberId(member.getId());
         assertThat(notifications).hasSize(1);
-        assertThat(notifications.get(0).getToken()).isEqualTo(fcmToken);
+        assertThat(notifications.get(0)).isEqualTo(fcmToken);
     }
 
     @Test
@@ -62,9 +61,9 @@ public class NotificationApiTest extends ApiBaseTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 
-        List<Notification> notifications = notificationRepository.findAllByMemberId(member.getId());
+        List<String> notifications = notificationRepository.findTokensByMemberId(member.getId());
         assertThat(notifications).hasSize(1);
-        assertThat(notifications.get(0).getToken()).isEqualTo("token");
+        assertThat(notifications.get(0)).isEqualTo("token");
     }
 
     @Test
@@ -91,9 +90,10 @@ public class NotificationApiTest extends ApiBaseTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 
-        List<Notification> notifications = notificationRepository.findAllByMemberId(member.getId());
+
+        List<String> notifications = notificationRepository.findTokensByMemberId(member.getId());
         assertThat(notifications).hasSize(2);
-        assertThat(notifications.get(0).getToken()).isEqualTo(fcmToken1);
-        assertThat(notifications.get(1).getToken()).isEqualTo(fcmToken2);
+        assertThat(notifications.get(0)).isEqualTo(fcmToken1);
+        assertThat(notifications.get(1)).isEqualTo(fcmToken2);
     }
 }

--- a/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
+++ b/src/test/java/com/exchangediary/notification/domain/NotificationRepositoryUnitTest.java
@@ -38,6 +38,7 @@ public class NotificationRepositoryUnitTest {
 
         Member self = setUpMember(1, group);
         createNotification("self-token", self);
+        setUpMember(2, group);
 
         entityManager.flush();
         entityManager.clear();
@@ -59,6 +60,7 @@ public class NotificationRepositoryUnitTest {
         Member self = setUpMember(1, group);
         createNotification("self-token", self);
         self.toggleNotification();
+        setUpMember(2, group);
 
         entityManager.flush();
         entityManager.clear();


### PR DESCRIPTION
## Work Description
> 알림 활성화 속성 추가 및 API 구현

- 사용자 테이블에 boolean 타입의 알림 활성화 (`on_notification`) 속성 추가했습니다.
- fcm 토큰 조회 시, `on_notification`이 true인 사용자에 대해서만 조회합니다.
- API 명세서와 동일하게 [알림 활성화 여부 조회](https://www.notion.so/yeeuniii/1cfd836989fc80388fa4cdcac0f65d17?pvs=4)와 [알림 활성화 전환](https://www.notion.so/yeeuniii/1cfd836989fc804f9d90db95bc29cb79?pvs=4) API 구현 및 테스트 작성하였습니다.
- 조금 더 구체적인 내용을 전달할 수 있게끔 알림 메시지를 수정했습니다.
알림에 필요한 정보들을 요청 / 응답과 비슷하게 record 형식의 dto를 작성하여 서비스에서 컨트롤러로 전달했습니다.

## ISSUE
- closed #491


## Screenshot
- Notification 단위 테스트 / API 테스트 수정되었고, 추가된 알림 활성화 API 테스트 작성하였고, 그 결과입니다.

<img width="472" alt="Screenshot 2025-04-12 at 5 08 28 AM" src="https://github.com/user-attachments/assets/b9e5d065-dc25-4a7d-8b55-392f72f97a7e" />

- 전체 테스트 코드 결과도 첨부합니다.

<img width="846" alt="Screenshot 2025-04-12 at 5 07 17 AM" src="https://github.com/user-attachments/assets/90fad811-7017-4fe0-91c7-d897ef7a2dd0" />


## To Reviewers
- 이번 v1.2에 포함되지 않는 댓글/답글에 대한 알림 메시지는 수정하지 않았습니다. v1.3 작업 시 수정하도록 하겠습니다.
- [알림 명세서](https://www.notion.so/yeeuniii/43253cc96545440c962dd1d59a338b80?pvs=4) 참고하여 메시지 수정하고 싶은 부분 있으면 말씀해주세요!!

