### PR TITLE
로그 파일 디렉터리 구조 변경

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=spring
-spring.profiles.active=local
+spring.profiles.active=prod
 
 # Database
 spring.datasource.driver-class-name=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
@@ -11,7 +11,7 @@ spring.sql.init.mode=always
 
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
-spring.flyway.baseline-version=1
+spring.flyway.baseline-version=0
 spring.flyway.locations=classpath:db/migration
 spring.flyway.user=${DB_USERNAME}
 spring.flyway.password=${DB_PASSWORD}

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -9,8 +9,8 @@
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/error/buddies-spring-error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
+            <fileNamePattern>./log/%d{yyyyMMdd}/error-%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
             <totalSizeCap>3GB</totalSizeCap>
         </rollingPolicy>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -4,8 +4,8 @@
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/info/buddies-spring-info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
+            <fileNamePattern>./log/%d{yyyyMMdd}/info-%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>10</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>

--- a/src/main/resources/file-sql-appender.xml
+++ b/src/main/resources/file-sql-appender.xml
@@ -4,8 +4,8 @@
             <pattern>${FILE_SQL_LOG_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/sql/buddies-spring-sql-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
+            <fileNamePattern>./log/%d{yyyyMMdd}/sql-%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>10</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>


### PR DESCRIPTION
## Work Description
> 로그 파일 디렉터리 구조 변경

- 기존 로그파일의 저장형식이었던 error / info /sql 디렉터리 구조에서 날짜의 디렉터리를 갖고, 그 안에서 error, info, sql 의 이름을 갖는 로그 파일을 저장하도록 형식을 변경하였습니다.
- 기존 설정되어있던 최대 파일 크기가 너무 크다고 판단하여 10MB로 줄였습니다.

## ISSUE
- closed #467


## Screenshot
<img width="1035" alt="Screenshot 2025-05-06 at 8 55 15 PM" src="https://github.com/user-attachments/assets/b0071aa5-85fc-48a4-bc03-2d4d61f681e3" />


